### PR TITLE
Use custom attachers

### DIFF
--- a/src/Http/Controllers/RepositoryAttachController.php
+++ b/src/Http/Controllers/RepositoryAttachController.php
@@ -4,8 +4,10 @@ namespace Binaryk\LaravelRestify\Http\Controllers;
 
 use Binaryk\LaravelRestify\Http\Requests\RepositoryAttachRequest;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Binaryk\LaravelRestify\Repositories\Repository;
 use DateTime;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class RepositoryAttachController extends RepositoryController
 {
@@ -14,12 +16,16 @@ class RepositoryAttachController extends RepositoryController
         $model = $request->findModelOrFail();
         $repository = $request->repository()->allowToUpdate($request);
 
+        if (is_callable($method = $this->guessMethodName($request, $repository))) {
+            return call_user_func($method, $request, $repository, $model);
+        }
+
         return $repository->attach(
             $request, $request->repositoryId,
             collect(Arr::wrap($request->input($request->relatedRepository)))
-            ->map(fn ($relatedRepositoryId) => $this->initializePivot(
-                $request, $model->{$request->viaRelationship ?? $request->relatedRepository}(), $relatedRepositoryId
-            ))
+                ->map(fn($relatedRepositoryId) => $this->initializePivot(
+                    $request, $model->{$request->viaRelationship ?? $request->relatedRepository}(), $relatedRepositoryId
+                ))
         );
     }
 
@@ -60,5 +66,22 @@ class RepositoryAttachController extends RepositoryController
         }
 
         return $pivot;
+    }
+
+    public function guessMethodName(RestifyRequest $request, Repository $repository): ?callable
+    {
+        $key = $request->relatedRepository;
+
+        if (array_key_exists($key, $repository::getAttachers()) && is_callable($cb = $repository::getAttachers()[$key])) {
+            return $cb;
+        }
+
+        $methodGuesser = "attach" . Str::studly($request->relatedRepository);
+
+        if (method_exists($repository, $methodGuesser)) {
+            return [$repository, $methodGuesser];
+        }
+
+        return null;
     }
 }

--- a/src/Http/Controllers/RepositoryAttachController.php
+++ b/src/Http/Controllers/RepositoryAttachController.php
@@ -23,7 +23,7 @@ class RepositoryAttachController extends RepositoryController
         return $repository->attach(
             $request, $request->repositoryId,
             collect(Arr::wrap($request->input($request->relatedRepository)))
-                ->map(fn($relatedRepositoryId) => $this->initializePivot(
+                ->map(fn ($relatedRepositoryId) => $this->initializePivot(
                     $request, $model->{$request->viaRelationship ?? $request->relatedRepository}(), $relatedRepositoryId
                 ))
         );
@@ -76,7 +76,7 @@ class RepositoryAttachController extends RepositoryController
             return $cb;
         }
 
-        $methodGuesser = "attach" . Str::studly($request->relatedRepository);
+        $methodGuesser = 'attach'.Str::studly($request->relatedRepository);
 
         if (method_exists($repository, $methodGuesser)) {
             return [$repository, $methodGuesser];

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -105,6 +105,13 @@ abstract class Repository implements RestifySearchable, JsonSerializable
     public static $middlewares = [];
 
     /**
+     * The list of attach callable's.
+     *
+     * @var array
+     */
+    public static $attachers = [];
+
+    /**
      * Get the underlying model instance for the resource.
      *
      * @return \Illuminate\Database\Eloquent\Model|LengthAwarePaginator
@@ -742,5 +749,10 @@ abstract class Repository implements RestifySearchable, JsonSerializable
     public static function collectMiddlewares(RestifyRequest $request): ?Collection
     {
         return collect(static::$middlewares);
+    }
+
+    public static function getAttachers(): array
+    {
+        return static::$attachers;
     }
 }

--- a/tests/Controllers/RepositoryAttachInterceptorTest.php
+++ b/tests/Controllers/RepositoryAttachInterceptorTest.php
@@ -12,12 +12,11 @@ class RepositoryAttachInterceptorTest extends IntegrationTest
         $role = factory(Role::class)->create();
         $user = $this->mockUsers()->first();
 
-        $this->postJson('restify-api/roles/' . $role->id . '/attach/users', [
+        $this->postJson('restify-api/roles/'.$role->id.'/attach/users', [
             'users' => $user->id,
         ])
             ->assertCreated();
 
         $this->assertDatabaseCount('model_has_roles', 1);
-
     }
 }

--- a/tests/Controllers/RepositoryAttachInterceptorTest.php
+++ b/tests/Controllers/RepositoryAttachInterceptorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Controllers;
+
+use Binaryk\LaravelRestify\Tests\Fixtures\Role\Role;
+use Binaryk\LaravelRestify\Tests\IntegrationTest;
+
+class RepositoryAttachInterceptorTest extends IntegrationTest
+{
+    public function test_can_intercept_attach_method()
+    {
+        $role = factory(Role::class)->create();
+        $user = $this->mockUsers()->first();
+
+        $this->postJson('restify-api/roles/' . $role->id . '/attach/users', [
+            'users' => $user->id,
+        ])
+            ->assertCreated();
+
+        $this->assertDatabaseCount('model_has_roles', 1);
+
+    }
+}

--- a/tests/Factories/Roleactory.php
+++ b/tests/Factories/Roleactory.php
@@ -1,0 +1,22 @@
+<?php
+
+use Binaryk\LaravelRestify\Tests\Fixtures\Role\Role;
+use Faker\Generator as Faker;
+
+/*
+|--------------------------------------------------------------------------
+| Model Factories
+|--------------------------------------------------------------------------
+|
+| This directory should contain each of the model factory definitions for
+| your application. Factories provide a convenient way to generate new
+| model instances for testing / seeding your application's database.
+|
+*/
+
+$factory->define(Role::class, function (Faker $faker) {
+    return [
+        'name' => $faker->word,
+        'guard_name' => 'web',
+    ];
+});

--- a/tests/Fixtures/Role/ModelHasRole.php
+++ b/tests/Fixtures/Role/ModelHasRole.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Fixtures\Role;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelHasRole extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'model_has_roles';
+
+    protected $guarded = ['id'];
+}

--- a/tests/Fixtures/Role/Role.php
+++ b/tests/Fixtures/Role/Role.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Fixtures\Role;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Role extends Model
+{
+    protected $table = 'roles';
+}

--- a/tests/Fixtures/Role/RoleRepository.php
+++ b/tests/Fixtures/Role/RoleRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Fixtures\Role;
+
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Binaryk\LaravelRestify\Repositories\Repository;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
+use Illuminate\Database\Eloquent\Model;
+
+class RoleRepository extends Repository
+{
+    public static $model = Role::class;
+
+    public function attachUsers(RestifyRequest $request, Repository $repository, Model $model)
+    {
+        ModelHasRole::create([
+            'role_id' => $model->id,
+            'model_type' => User::class,
+            'model_id' => $request->get('users'),
+        ]);
+
+        return $this->response()->created();
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -13,6 +13,7 @@ use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostUnauthorizedFieldRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostWithHiddenFieldRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostWithUnauthorizedFieldsRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\Role\RoleRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -188,6 +189,7 @@ abstract class IntegrationTest extends TestCase
             PostWithUnauthorizedFieldsRepository::class,
             PostUnauthorizedFieldRepository::class,
             PostWithHiddenFieldRepository::class,
+            RoleRepository::class,
         ]);
     }
 

--- a/tests/Migrations/2019_12_22_000006_create_roles_table.php
+++ b/tests/Migrations/2019_12_22_000006_create_roles_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRolesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
+
+        Schema::create('model_has_roles', function (Blueprint $table) {
+            $table->unsignedBigInteger('role_id');
+
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+            $table->index(['model_id', 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign('role_id')
+                ->references('id')
+                ->on('roles')
+                ->onDelete('cascade');
+
+            $table->primary(['role_id', 'model_id', 'model_type'],
+                'model_has_roles_role_model_type_primary');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('roles');
+    }
+}


### PR DESCRIPTION
## Added

Ability to setup your own attachers. For example if you want to attach users to a role, and you don't want to use the default attach method. In this case you can override the attach method like this:

```
// RoleRepository.php

public function attachUsers(RestifyRequest $request, Repository $repository, Model $model)
    {
        ModelHasRole::create([
            'role_id' => $model->id,
            'model_type' => User::class,
            'model_id' => $request->get('users'),
        ]);

        return $this->response()->created();
    }
```

The URL used for attach will remain the same as for a normal attach: 

```
'restify-api/roles/' . $role->id . '/attach/users'
```