### PR TITLE
Eager loading related

### DIFF
--- a/docs/docs/3.0/repository-pattern/repository-pattern.md
+++ b/docs/docs/3.0/repository-pattern/repository-pattern.md
@@ -580,3 +580,16 @@ public static function getAttachers(): array
     },
 }
 ```
+
+## Force eager loading
+
+However, Laravel Restify [provides eager](/search/) loading based on the query `related` property, 
+you may want to force eager load a relationship in terms of using it in fields, or whatever else: 
+
+```php
+// UserRepository.php
+
+public static $with = ['posts'];
+```
+
+

--- a/docs/docs/3.0/search/search.md
+++ b/docs/docs/3.0/search/search.md
@@ -125,7 +125,7 @@ When get a repository index or details about a single entity, often we have to g
 This eager loading is configurable by Restify as follow: 
 
 ```php
-public static $withs = ['posts'];
+public static $related = ['posts'];
 ```
 
 This means that we could use `posts` query for eager loading posts:
@@ -133,3 +133,4 @@ This means that we could use `posts` query for eager loading posts:
 ```http request
 GET: /restify-api/users?with=posts
 ```
+

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -50,7 +50,7 @@ abstract class Repository implements RestifySearchable, JsonSerializable
     /**
      * The list of relations available for the details or index.
      *
-     * e.g. ?with=users
+     * e.g. ?related=users
      * @var array
      */
     public static $related;
@@ -110,6 +110,13 @@ abstract class Repository implements RestifySearchable, JsonSerializable
      * @var array
      */
     public static $attachers = [];
+
+    /**
+     * The relationships that should be eager loaded when performing an index query.
+     *
+     * @var array
+     */
+    public static $with = [];
 
     /**
      * Get the underlying model instance for the resource.

--- a/src/Services/Search/RepositorySearchService.php
+++ b/src/Services/Search/RepositorySearchService.php
@@ -182,7 +182,7 @@ class RepositorySearchService extends Searchable
 
     protected function applyIndexQuery(RestifyRequest $request, Repository $repository)
     {
-        return fn ($query) => $repository::indexQuery($request, $query);
+        return fn ($query) => $repository::indexQuery($request, $query->with(static::$with));
     }
 
     protected function applyFilters(RestifyRequest $request, Repository $repository, $query)

--- a/src/Services/Search/RepositorySearchService.php
+++ b/src/Services/Search/RepositorySearchService.php
@@ -182,7 +182,7 @@ class RepositorySearchService extends Searchable
 
     protected function applyIndexQuery(RestifyRequest $request, Repository $repository)
     {
-        return fn ($query) => $repository::indexQuery($request, $query->with(static::$with));
+        return fn ($query) => $repository::indexQuery($request, $query->with($repository::$with));
     }
 
     protected function applyFilters(RestifyRequest $request, Repository $repository, $query)


### PR DESCRIPTION
## Force eager loading

However, Laravel Restify [provides eager](/search/) loading based on the query `related` property, 
you may want to force eager load a relationship in terms of using it in fields, or whatever else: 

```php
// UserRepository.php

public static $with = ['posts'];
```