### PR TITLE
Filter definition.

### DIFF
--- a/docs/docs/4.0/search/search.md
+++ b/docs/docs/4.0/search/search.md
@@ -154,6 +154,38 @@ So now you can query this:
 GET: /api/restify/users?is_active=true
 ```
 
+### Match definition
+
+You can implement a match filter definition, and specify for example related repository:
+
+```php
+  public static $match = [
+        'title' => 'string',
+        'user_id' => MatchFilter::make()
+            ->setType('int')
+            ->setRelatedRepositoryKey(UserRepository::uriKey()),
+];
+```
+When you will list this filter (with `posts/filters?only=matches`), you will get: 
+
+```json
+  {
+      "class": "Binaryk\LaravelRestify\Filters\MatchFilter"
+      "key": "matches"
+      "type": "string"
+      "column": "title"
+      "options": []
+    },
+    {
+      "class": "Binaryk\LaravelRestify\Filters\MatchFilter"
+      "key": "matches"
+      "type": "int"
+      "column": "user_id"
+      "options": []
+      "related_repository_key": "users"
+      "related_repository_url": "//users"
+    }
+```
 ## Sort 
 When index query entities, usually we have to sort by specific attributes. 
 

--- a/src/Commands/FilterCommand.php
+++ b/src/Commands/FilterCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Commands;
+
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+
+class FilterCommand extends GeneratorCommand
+{
+    use ConfirmableTrait;
+
+    protected $name = 'restify:filter';
+
+    protected $description = 'Create a new filter class';
+
+    protected $type = 'Filter';
+
+    public function handle()
+    {
+        if (parent::handle() === false && ! $this->option('force')) {
+            return false;
+        }
+    }
+
+    /**
+     * Build the class with the given name.
+     * This method should return the file class content.
+     *
+     * @param string $name
+     * @return string
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function buildClass($name)
+    {
+        if (false === Str::endsWith($name, 'Filter')) {
+            $name .= 'Filter';
+        }
+
+        return tap(parent::buildClass($name), function ($stub) use ($name) {
+            return str_replace(['{{ attribute }}', '{{ query }}'], Str::snake(
+                Str::beforeLast(class_basename($name), 'Filter')
+            ), $stub);
+        });
+    }
+
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/filter.stub';
+    }
+
+    protected function getPath($name)
+    {
+        if (false === Str::endsWith($name, 'Filter')) {
+            $name .= 'Filter';
+        }
+
+        return parent::getPath($name);
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Restify\Matchers';
+    }
+}

--- a/src/Commands/stubs/filter.stub
+++ b/src/Commands/stubs/filter.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace DummyNamespace;
+
+use Binaryk\LaravelRestify\Repositories\Matchable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+
+class DummyClass implements Matchable
+{
+    public function handle(Request $request, Builder $query)
+    {
+        // $query->where('{{ attribute }}', $request->input('{{ query }}'));
+    }
+}

--- a/src/Commands/stubs/filter.stub
+++ b/src/Commands/stubs/filter.stub
@@ -2,13 +2,12 @@
 
 namespace DummyNamespace;
 
-use Binaryk\LaravelRestify\Repositories\Matchable;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Http\Request;
+use Binaryk\LaravelRestify\Filter;
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 
-class DummyClass implements Matchable
+class DummyClass extends Filter
 {
-    public function handle(Request $request, Builder $query)
+    public function filter(RestifyRequest $request, $query, $value)
     {
         // $query->where('{{ attribute }}', $request->input('{{ query }}'));
     }

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -2,14 +2,11 @@
 
 namespace Binaryk\LaravelRestify;
 
-use Binaryk\LaravelRestify\Filters\FilterDefinition;
-use Binaryk\LaravelRestify\Filters\MatchFilter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
 use Binaryk\LaravelRestify\Traits\Make;
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use JsonSerializable;
 

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -87,13 +87,9 @@ abstract class Filter implements JsonSerializable
             return static::$uriKey;
         }
 
-        $kebabWithoutRepository = Str::kebab(Str::replaceLast('Filter', '', class_basename(get_called_class())));
+        $kebabWithoutFilter = Str::kebab(Str::replaceLast('Filter', '', class_basename(get_called_class())));
 
-        /**
-         * e.g. UserRepository => users
-         * e.g. LaravelEntityRepository => laravel-entities.
-         */
-        return Str::plural($kebabWithoutRepository);
+        return Str::plural($kebabWithoutFilter);
     }
 
     public function jsonSerialize()

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -26,6 +26,8 @@ abstract class Filter implements JsonSerializable
 
     public $relatedRepositoryKey;
 
+    public Repository $repository;
+
     public function __construct()
     {
         $this->booted();
@@ -65,6 +67,13 @@ abstract class Filter implements JsonSerializable
         return $this->column;
     }
 
+    public function setColumn(string $column): self
+    {
+        $this->column = $column;
+
+        return $this;
+    }
+
     public function setType(string $type): self
     {
         $this->type = $type;
@@ -101,6 +110,13 @@ abstract class Filter implements JsonSerializable
     public function setRelatedRepositoryKey(string $repositoryKey): self
     {
         $this->relatedRepositoryKey = $repositoryKey;
+
+        return $this;
+    }
+
+    public function setRepository(Repository $repository): self
+    {
+        $this->repository = $repository;
 
         return $this;
     }

--- a/src/Filters/FilterDefinition.php
+++ b/src/Filters/FilterDefinition.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Filters;
+
+use Binaryk\LaravelRestify\Repositories\Repository;
+use Binaryk\LaravelRestify\Restify;
+use JsonSerializable;
+
+abstract class FilterDefinition implements JsonSerializable
+{
+    public static string $type = 'string';
+
+    public static string $relatedRepositoryKey;
+
+    public function getType(): string
+    {
+        return static::$type;
+    }
+
+    public function getRelatedRepositoryKey(): ?string
+    {
+        return static::$relatedRepositoryKey;
+    }
+
+    public function getRelatedRepositoryUrl(): ?string
+    {
+        return ($key = $this->getRelatedRepositoryKey())
+            ? with(Restify::repositoryForKey($key), function ($repository = null) {
+                if (is_subclass_of($repository, Repository::class)) {
+                    return Restify::path($repository::uriKey());
+                }
+            })
+            : null;
+    }
+
+    public function jsonSerialize()
+    {
+        return with([
+            'type' => $this->getType(),
+        ], function (array $initial) {
+            return static::$relatedRepositoryKey
+                ? array_merge($initial, [
+                    'related_repository_key' => $this->getRelatedRepositoryKey(),
+                    'related_repository_url' => $this->getRelatedRepositoryUrl(),
+                ])
+                : $initial;
+        });
+    }
+}

--- a/src/Filters/MatchFilter.php
+++ b/src/Filters/MatchFilter.php
@@ -11,6 +11,8 @@ class MatchFilter extends Filter
 {
     public $column = 'id';
 
+    public Repository $repository;
+
     public static $uriKey = 'matches';
 
     public function filter(RestifyRequest $request, $query, $value)
@@ -19,18 +21,19 @@ class MatchFilter extends Filter
         $query->where($this->column, $value);
     }
 
-    public static function makeFromSimple($column, $type): self
+    public static function makeFromSimple(Repository $repository, $column, $type): self
     {
-        return tap(new static, function (MatchFilter $filter) use ($column, $type) {
+        return tap(new static, function (MatchFilter $filter) use ($column, $type, $repository) {
             $filter->type = $type;
             $filter->column = $column;
+            $filter->repository = $repository;
         });
     }
 
     public static function makeForRepository(Repository $repository): Collection
     {
-        return collect($repository::getMatchByFields())->map(function ($type, $column) {
-            return static::makeFromSimple($column, $type);
+        return collect($repository::getMatchByFields())->map(function ($type, $column) use ($repository) {
+            return static::makeFromSimple($repository, $column, $type);
         })->values();
     }
 
@@ -41,6 +44,7 @@ class MatchFilter extends Filter
             'type' => $this->getType(),
             'key' => static::uriKey(),
             'column' => $this->column,
+            'repository_key' => $this->repository::uriKey(),
         ];
     }
 }

--- a/src/Filters/MatchFilter.php
+++ b/src/Filters/MatchFilter.php
@@ -2,8 +2,10 @@
 
 namespace Binaryk\LaravelRestify\Filters;
 
+use Binaryk\LaravelRestify\Contracts\RestifySearchable;
 use Binaryk\LaravelRestify\Filter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Illuminate\Support\Str;
 
 class MatchFilter extends Filter
 {
@@ -11,7 +13,69 @@ class MatchFilter extends Filter
 
     public function filter(RestifyRequest $request, $query, $value)
     {
-        //@todo improve this
-        $query->where($this->column, $value);
+        $key = Str::afterLast($this->column, '.');
+        $negation = false;
+
+        if ($request->has('-' . $key)) {
+            $negation = true;
+        }
+
+        if (empty($value)) {
+            return $query;
+        }
+
+        $match = $value;
+
+        if ($negation) {
+            $key = Str::after($key, '-');
+        }
+
+        $field = $this->column;
+
+        if ($match === 'null') {
+            if ($negation) {
+                $query->whereNotNull($field);
+            } else {
+                $query->whereNull($field);
+            }
+        } else {
+            switch ($this->getType()) {
+                case RestifySearchable::MATCH_TEXT:
+                case 'string':
+                    $query->where($field, $negation ? '!=' : '=', $match);
+                    break;
+                case RestifySearchable::MATCH_BOOL:
+                case 'boolean':
+                    if ($match === 'false') {
+                        $query->where(function ($query) use ($field, $negation) {
+                            if ($negation) {
+                                return $query->where($field, true);
+                            } else {
+                                return $query->where($field, '=', false)->orWhereNull($field);
+                            }
+                        });
+                        break;
+                    }
+                    $query->where($field, $negation ? '!=' : '=', true);
+                    break;
+                case RestifySearchable::MATCH_INTEGER:
+                case 'number':
+                case 'int':
+                    $query->where($field, $negation ? '!=' : '=', (int)$match);
+                    break;
+                case RestifySearchable::MATCH_DATETIME:
+                    $query->whereDate($field, $negation ? '!=' : '=', $match);
+                    break;
+                case RestifySearchable::MATCH_ARRAY:
+                    $match = explode(',', $match);
+
+                    if ($negation) {
+                        $query->whereNotIn($field, $match);
+                    } else {
+                        $query->whereIn($field, $match);
+                    }
+                    break;
+            }
+        }
     }
 }

--- a/src/Filters/MatchFilter.php
+++ b/src/Filters/MatchFilter.php
@@ -4,47 +4,14 @@ namespace Binaryk\LaravelRestify\Filters;
 
 use Binaryk\LaravelRestify\Filter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
-use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\Support\Collection;
 
 class MatchFilter extends Filter
 {
-    public $column = 'id';
-
-    public Repository $repository;
-
     public static $uriKey = 'matches';
 
     public function filter(RestifyRequest $request, $query, $value)
     {
         //@todo improve this
         $query->where($this->column, $value);
-    }
-
-    public static function makeFromSimple(Repository $repository, $column, $type): self
-    {
-        return tap(new static, function (MatchFilter $filter) use ($column, $type, $repository) {
-            $filter->type = $type;
-            $filter->column = $column;
-            $filter->repository = $repository;
-        });
-    }
-
-    public static function makeForRepository(Repository $repository): Collection
-    {
-        return collect($repository::getMatchByFields())->map(function ($type, $column) use ($repository) {
-            return static::makeFromSimple($repository, $column, $type);
-        })->values();
-    }
-
-    public function jsonSerialize()
-    {
-        return [
-            'class' => static::class,
-            'type' => $this->getType(),
-            'key' => static::uriKey(),
-            'column' => $this->column,
-            'repository_key' => $this->repository::uriKey(),
-        ];
     }
 }

--- a/src/Filters/SearchableFilter.php
+++ b/src/Filters/SearchableFilter.php
@@ -11,6 +11,8 @@ class SearchableFilter extends Filter
 {
     public $column = 'id';
 
+    public Repository $repository;
+
     public static $uriKey = 'searchables';
 
     public function filter(RestifyRequest $request, $query, $value)
@@ -19,17 +21,18 @@ class SearchableFilter extends Filter
         $query->where($this->column, 'LIKE', "%{$value}%");
     }
 
-    public static function makeFromSimple($column): self
+    public static function makeFromSimple(Repository $repository, $column): self
     {
-        return tap(new static, function (SearchableFilter $filter) use ($column) {
+        return tap(new static, function (SearchableFilter $filter) use ($column, $repository) {
             $filter->column = $column;
+            $filter->repository = $repository;
         });
     }
 
     public static function makeForRepository(Repository $repository): Collection
     {
-        return collect($repository::getSearchableFields())->map(function ($column) {
-            return static::makeFromSimple($column);
+        return collect($repository::getSearchableFields())->map(function ($column) use ($repository) {
+            return static::makeFromSimple($repository, $column);
         });
     }
 
@@ -39,6 +42,7 @@ class SearchableFilter extends Filter
             'class' => static::class,
             'key' => static::uriKey(),
             'column' => $this->column,
+            'repository_key' => $this->repository::uriKey(),
         ];
     }
 }

--- a/src/Filters/SearchableFilter.php
+++ b/src/Filters/SearchableFilter.php
@@ -11,7 +11,10 @@ class SearchableFilter extends Filter
 
     public function filter(RestifyRequest $request, $query, $value)
     {
-        //@todo improve this
-        $query->where($this->column, 'LIKE', "%{$value}%");
+        $connectionType = $this->repository->model()->getConnection()->getDriverName();
+
+        $likeOperator = $connectionType == 'pgsql' ? 'ilike' : 'like';
+
+        $query->orWhere($this->column, $likeOperator, '%' . $value . '%');
     }
 }

--- a/src/Filters/SearchableFilter.php
+++ b/src/Filters/SearchableFilter.php
@@ -4,45 +4,14 @@ namespace Binaryk\LaravelRestify\Filters;
 
 use Binaryk\LaravelRestify\Filter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
-use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\Support\Collection;
 
 class SearchableFilter extends Filter
 {
-    public $column = 'id';
-
-    public Repository $repository;
-
     public static $uriKey = 'searchables';
 
     public function filter(RestifyRequest $request, $query, $value)
     {
         //@todo improve this
         $query->where($this->column, 'LIKE', "%{$value}%");
-    }
-
-    public static function makeFromSimple(Repository $repository, $column): self
-    {
-        return tap(new static, function (SearchableFilter $filter) use ($column, $repository) {
-            $filter->column = $column;
-            $filter->repository = $repository;
-        });
-    }
-
-    public static function makeForRepository(Repository $repository): Collection
-    {
-        return collect($repository::getSearchableFields())->map(function ($column) use ($repository) {
-            return static::makeFromSimple($repository, $column);
-        });
-    }
-
-    public function jsonSerialize()
-    {
-        return [
-            'class' => static::class,
-            'key' => static::uriKey(),
-            'column' => $this->column,
-            'repository_key' => $this->repository::uriKey(),
-        ];
     }
 }

--- a/src/Filters/SortableFilter.php
+++ b/src/Filters/SortableFilter.php
@@ -4,45 +4,14 @@ namespace Binaryk\LaravelRestify\Filters;
 
 use Binaryk\LaravelRestify\Filter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
-use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\Support\Collection;
 
 class SortableFilter extends Filter
 {
-    public $column = 'id';
-
-    public Repository $repository;
-
     public static $uriKey = 'sortables';
 
     public function filter(RestifyRequest $request, $query, $direction)
     {
         //@todo improve this
         $query->orderBy($this->column, $direction);
-    }
-
-    public static function makeFromSimple(Repository $repository, $column): self
-    {
-        return tap(new static, function (SortableFilter $filter) use ($column, $repository) {
-            $filter->column = $column;
-            $filter->repository = $repository;
-        });
-    }
-
-    public static function makeForRepository(Repository $repository): Collection
-    {
-        return collect($repository::getOrderByFields())->map(function ($column) use ($repository) {
-            return static::makeFromSimple($repository, $column);
-        });
-    }
-
-    public function jsonSerialize()
-    {
-        return [
-            'class' => static::class,
-            'key' => static::uriKey(),
-            'column' => $this->column,
-            'repository_key' => $this->repository::uriKey(),
-        ];
     }
 }

--- a/src/Filters/SortableFilter.php
+++ b/src/Filters/SortableFilter.php
@@ -11,6 +11,8 @@ class SortableFilter extends Filter
 {
     public $column = 'id';
 
+    public Repository $repository;
+
     public static $uriKey = 'sortables';
 
     public function filter(RestifyRequest $request, $query, $direction)
@@ -19,17 +21,18 @@ class SortableFilter extends Filter
         $query->orderBy($this->column, $direction);
     }
 
-    public static function makeFromSimple($column): self
+    public static function makeFromSimple(Repository $repository, $column): self
     {
-        return tap(new static, function (SortableFilter $filter) use ($column) {
+        return tap(new static, function (SortableFilter $filter) use ($column, $repository) {
             $filter->column = $column;
+            $filter->repository = $repository;
         });
     }
 
     public static function makeForRepository(Repository $repository): Collection
     {
-        return collect($repository::getOrderByFields())->map(function ($column) {
-            return static::makeFromSimple($column);
+        return collect($repository::getOrderByFields())->map(function ($column) use ($repository) {
+            return static::makeFromSimple($repository, $column);
         });
     }
 
@@ -39,6 +42,7 @@ class SortableFilter extends Filter
             'class' => static::class,
             'key' => static::uriKey(),
             'column' => $this->column,
+            'repository_key' => $this->repository::uriKey(),
         ];
     }
 }

--- a/src/Filters/SortableFilter.php
+++ b/src/Filters/SortableFilter.php
@@ -11,7 +11,10 @@ class SortableFilter extends Filter
 
     public function filter(RestifyRequest $request, $query, $direction)
     {
-        //@todo improve this
-        $query->orderBy($this->column, $direction);
+        $query->orderBy($this->column,
+            $direction === '-'
+                ? 'desc'
+                : 'asc'
+        );
     }
 }

--- a/src/Http/Controllers/RepositoryFilterController.php
+++ b/src/Http/Controllers/RepositoryFilterController.php
@@ -2,6 +2,7 @@
 
 namespace Binaryk\LaravelRestify\Http\Controllers;
 
+use Binaryk\LaravelRestify\Filter;
 use Binaryk\LaravelRestify\Filters\MatchFilter;
 use Binaryk\LaravelRestify\Filters\SearchableFilter;
 use Binaryk\LaravelRestify\Filters\SortableFilter;
@@ -18,19 +19,11 @@ class RepositoryFilterController extends RepositoryController
             $repository->availableFilters($request)
                 ->when($request->has('include'), function (Collection $collection) use ($repository, $request) {
                     return $collection->merge(
-                        collect(str_getcsv($request->input('include')))->map(fn ($key) => collect([
-                            SearchableFilter::uriKey() => SearchableFilter::class,
-                            MatchFilter::uriKey() => MatchFilter::class,
-                            SortableFilter::uriKey() => SortableFilter::class,
-                        ])->get($key))->flatMap(fn ($filterable) => $filterable::makeForRepository($repository))
+                        collect(str_getcsv($request->input('include')))->flatMap(fn($key) => $repository::collectFilters($key))
                     );
                 })
                 ->when($request->has('only'), function (Collection $collection) use ($repository, $request) {
-                    return collect(str_getcsv($request->input('only')))->map(fn ($key) => collect([
-                        SearchableFilter::uriKey() => SearchableFilter::class,
-                        MatchFilter::uriKey() => MatchFilter::class,
-                        SortableFilter::uriKey() => SortableFilter::class,
-                    ])->get($key))->flatMap(fn ($filterable) => $filterable::makeForRepository($repository));
+                    return collect(str_getcsv($request->input('only')))->flatMap(fn($key) => $repository::collectFilters($key));
                 })
         );
     }

--- a/src/Http/Controllers/RepositoryFilterController.php
+++ b/src/Http/Controllers/RepositoryFilterController.php
@@ -2,10 +2,6 @@
 
 namespace Binaryk\LaravelRestify\Http\Controllers;
 
-use Binaryk\LaravelRestify\Filter;
-use Binaryk\LaravelRestify\Filters\MatchFilter;
-use Binaryk\LaravelRestify\Filters\SearchableFilter;
-use Binaryk\LaravelRestify\Filters\SortableFilter;
 use Binaryk\LaravelRestify\Http\Requests\RepositoryFiltersRequest;
 use Illuminate\Support\Collection;
 
@@ -19,11 +15,11 @@ class RepositoryFilterController extends RepositoryController
             $repository->availableFilters($request)
                 ->when($request->has('include'), function (Collection $collection) use ($repository, $request) {
                     return $collection->merge(
-                        collect(str_getcsv($request->input('include')))->flatMap(fn($key) => $repository::collectFilters($key))
+                        collect(str_getcsv($request->input('include')))->flatMap(fn ($key) => $repository::collectFilters($key))
                     );
                 })
                 ->when($request->has('only'), function (Collection $collection) use ($repository, $request) {
-                    return collect(str_getcsv($request->input('only')))->flatMap(fn($key) => $repository::collectFilters($key));
+                    return collect(str_getcsv($request->input('only')))->flatMap(fn ($key) => $repository::collectFilters($key));
                 })
         );
     }

--- a/src/Http/Controllers/RepositoryFilterController.php
+++ b/src/Http/Controllers/RepositoryFilterController.php
@@ -16,7 +16,6 @@ class RepositoryFilterController extends RepositoryController
 
         return $this->response()->data(
             $repository->availableFilters($request)
-                // After
                 ->when($request->has('include'), function (Collection $collection) use ($repository, $request) {
                     return $collection->merge(
                         collect(str_getcsv($request->input('include')))->map(fn ($key) => collect([

--- a/src/LaravelRestifyServiceProvider.php
+++ b/src/LaravelRestifyServiceProvider.php
@@ -6,6 +6,7 @@ use Binaryk\LaravelRestify\Commands\ActionCommand;
 use Binaryk\LaravelRestify\Commands\BaseRepositoryCommand;
 use Binaryk\LaravelRestify\Commands\CheckPassport;
 use Binaryk\LaravelRestify\Commands\DevCommand;
+use Binaryk\LaravelRestify\Commands\FilterCommand;
 use Binaryk\LaravelRestify\Commands\MatcherCommand;
 use Binaryk\LaravelRestify\Commands\PolicyCommand;
 use Binaryk\LaravelRestify\Commands\Refresh;
@@ -63,6 +64,7 @@ class LaravelRestifyServiceProvider extends ServiceProvider
             RepositoryCommand::class,
             ActionCommand::class,
             MatcherCommand::class,
+            FilterCommand::class,
             DevCommand::class,
         ]);
     }

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -901,7 +901,7 @@ abstract class Repository implements RestifySearchable, JsonSerializable
     public function serializeForShow(RestifyRequest $request): array
     {
         return $this->filter([
-            'id' => $this->when($this->resource->id, fn () => $this->getId($request)),
+            'id' => $this->when(optional($this->resource)->id, fn () => $this->getId($request)),
             'type' => $this->when($type = $this->getType($request), $type),
             'attributes' => $request->isShowRequest() ? $this->resolveShowAttributes($request) : $this->resolveIndexAttributes($request),
             'relationships' => $this->when(value($related = $this->resolveRelationships($request)), $related),

--- a/src/Services/Search/RepositorySearchService.php
+++ b/src/Services/Search/RepositorySearchService.php
@@ -2,8 +2,10 @@
 
 namespace Binaryk\LaravelRestify\Services\Search;
 
-use Binaryk\LaravelRestify\Contracts\RestifySearchable;
 use Binaryk\LaravelRestify\Filter;
+use Binaryk\LaravelRestify\Filters\MatchFilter;
+use Binaryk\LaravelRestify\Filters\SearchableFilter;
+use Binaryk\LaravelRestify\Filters\SortableFilter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Binaryk\LaravelRestify\Repositories\Matchable;
 use Binaryk\LaravelRestify\Repositories\Repository;
@@ -34,15 +36,15 @@ class RepositorySearchService extends Searchable
         foreach ($this->repository->getMatchByFields($request) as $key => $type) {
             $negation = false;
 
-            if ($request->has('-'.$key)) {
+            if ($request->has('-' . $key)) {
                 $negation = true;
             }
 
-            if (! $request->has($negation ? '-'.$key : $key) && ! data_get($extra, "match.$key")) {
+            if (! $request->has($negation ? '-' . $key : $key) && ! data_get($extra, "match.$key")) {
                 continue;
             }
 
-            $match = $request->input($negation ? '-'.$key : $key, data_get($extra, "match.$key"));
+            $match = $request->input($negation ? '-' . $key : $key, data_get($extra, "match.$key"));
 
             if ($negation) {
                 $key = Str::after($key, '-');
@@ -52,67 +54,38 @@ class RepositorySearchService extends Searchable
                 continue;
             }
 
-            $field = $model->qualifyColumn($key);
+            if (is_callable($type)) {
+                call_user_func_array($type, [
+                    $request, $query,
+                ]);
 
-            if ($match === 'null') {
-                if ($negation) {
-                    $query->whereNotNull($field);
-                } else {
-                    $query->whereNull($field);
-                }
-            } else {
-                switch ($this->repository->getMatchByFields()[$key]) {
-                    case RestifySearchable::MATCH_TEXT:
-                    case 'string':
-                        $query->where($field, $negation ? '!=' : '=', $match);
-                        break;
-                    case RestifySearchable::MATCH_BOOL:
-                    case 'boolean':
-                        if ($match === 'false') {
-                            $query->where(function ($query) use ($field, $negation) {
-                                if ($negation) {
-                                    return $query->where($field, true);
-                                } else {
-                                    return $query->where($field, '=', false)->orWhereNull($field);
-                                }
-                            });
-                            break;
-                        }
-                        $query->where($field, $negation ? '!=' : '=', true);
-                        break;
-                    case RestifySearchable::MATCH_INTEGER:
-                    case 'number':
-                    case 'int':
-                        $query->where($field, $negation ? '!=' : '=', (int) $match);
-                        break;
-                    case RestifySearchable::MATCH_DATETIME:
-                        $query->whereDate($field, $negation ? '!=' : '=', $match);
-                        break;
-                    case RestifySearchable::MATCH_ARRAY:
-                        $match = explode(',', $match);
-
-                        if ($negation) {
-                            $query->whereNotIn($field, $match);
-                        } else {
-                            $query->whereIn($field, $match);
-                        }
-                        break;
-                    default:
-                        if (is_callable($this->repository->getMatchByFields($request)[$key])) {
-                            call_user_func_array($this->repository->getMatchByFields($request)[$key], [
-                                $request, $query,
-                            ]);
-                        }
-
-                        if (is_subclass_of($this->repository->getMatchByFields($request)[$key], Matchable::class)) {
-                            call_user_func_array([
-                                app($this->repository->getMatchByFields($request)[$key]), 'handle',
-                            ], [
-                                $request, $query,
-                            ]);
-                        }
-                }
+                continue;
             }
+
+            if (is_subclass_of($type, Matchable::class)) {
+                call_user_func_array([
+                    app($type), 'handle',
+                ], [
+                    $request, $query,
+                ]);
+
+                continue;
+            }
+
+            $filter = $type instanceof Filter
+                ? $type
+                : MatchFilter::make()->setType($type);
+
+            $filter->setRepository($this->repository)
+                ->setColumn(
+                    $filter->column ?? $model->qualifyColumn($key)
+                );
+
+            call_user_func_array([
+                $filter, 'filter',
+            ], [
+                $request, $query, $match
+            ]);
         }
 
         return $query;
@@ -126,16 +99,17 @@ class RepositorySearchService extends Searchable
             $orderings = $extra['sort'];
         }
 
+
         $params = array_filter($orderings);
 
         if (is_array($params) === true && empty($params) === false) {
             foreach ($params as $param) {
-                $this->setOrder($query, $param);
+                $this->setOrder($request, $query, $param);
             }
         }
 
         if (empty($params) === true) {
-            $this->setOrder($query, '+'.$this->repository->newModel()->getKeyName());
+            $this->setOrder($request, $query, '+' . $this->repository->newModel()->getKeyName());
         }
 
         return $query;
@@ -164,7 +138,7 @@ class RepositorySearchService extends Searchable
 
         $model = $query->getModel();
 
-        $query->where(function ($query) use ($search, $model) {
+        $query->where(function ($query) use ($search, $model, $request) {
             $connectionType = $model->getConnection()->getDriverName();
 
             $canSearchPrimaryKey = is_numeric($search) &&
@@ -176,17 +150,28 @@ class RepositorySearchService extends Searchable
                 $query->orWhere($query->getModel()->getQualifiedKeyName(), $search);
             }
 
-            $likeOperator = $connectionType == 'pgsql' ? 'ilike' : 'like';
 
-            foreach ($this->repository->getSearchableFields() as $column) {
-                $query->orWhere($model->qualifyColumn($column), $likeOperator, '%'.$search.'%');
+            foreach ($this->repository->getSearchableFields() as $key => $column) {
+                $filter = $column instanceof Filter
+                    ? $column
+                    : SearchableFilter::make()->setColumn(
+                        $model->qualifyColumn(is_numeric($key) ? $column : $key)
+                    );
+
+                $filter
+                    ->setRepository($this->repository)
+                    ->setColumn(
+                        $filter->column ?? $model->qualifyColumn(is_numeric($key) ? $column : $key)
+                    );
+
+                $filter->filter($request, $query, $search);
             }
         });
 
         return $query;
     }
 
-    public function setOrder($query, $param)
+    public function setOrder(RestifyRequest $request, $query, $param)
     {
         if ($param === 'random') {
             $query->inRandomOrder();
@@ -212,19 +197,23 @@ class RepositorySearchService extends Searchable
         $field = $field ?? $this->repository->newModel()->getKeyName();
 
         if (isset($field)) {
-            if (in_array($field, $this->repository->getOrderByFields()) === true) {
-                if ($order === '-') {
-                    $query->orderBy($field, 'desc');
-                }
+            foreach ($this->repository->getOrderByFields() as $column => $definitionField) {
+                $filter = $definitionField instanceof Filter
+                    ? $definitionField
+                    : SortableFilter::make();
 
-                if ($order === '+') {
-                    $query->orderBy($field, 'asc');
-                }
+                $filter->setRepository($this->repository)
+                    ->setColumn(
+                        $filter->column ?? $query->qualifyColumn($field)
+                    );
+
+                $filter->filter($request, $query, $order);
             }
 
             if ($field === 'random') {
                 $query->orderByRaw('RAND()');
             }
+
         }
 
         return $query;
@@ -232,12 +221,12 @@ class RepositorySearchService extends Searchable
 
     protected function applyIndexQuery(RestifyRequest $request, Repository $repository)
     {
-        return fn ($query) => $repository::indexQuery($request, $query);
+        return fn($query) => $repository::indexQuery($request, $query);
     }
 
     protected function applyMainQuery(RestifyRequest $request, Repository $repository)
     {
-        return fn ($query) => $repository::mainQuery($request, $query->with($repository::getWiths()));
+        return fn($query) => $repository::mainQuery($request, $query->with($repository::getWiths()));
     }
 
     protected function applyFilters(RestifyRequest $request, Repository $repository, $query)
@@ -268,7 +257,7 @@ class RepositorySearchService extends Searchable
                     return $matchingFilter;
                 })
                 ->filter()
-                ->each(fn (Filter $filter) => $filter->filter($request, $query, $filter->value));
+                ->each(fn(Filter $filter) => $filter->filter($request, $query, $filter->value));
         }
 
         return $query;

--- a/src/Traits/InteractWithSearch.php
+++ b/src/Traits/InteractWithSearch.php
@@ -6,7 +6,6 @@ use Binaryk\LaravelRestify\Filter;
 use Binaryk\LaravelRestify\Filters\MatchFilter;
 use Binaryk\LaravelRestify\Filters\SearchableFilter;
 use Binaryk\LaravelRestify\Filters\SortableFilter;
-use Binaryk\LaravelRestify\Repositories\Repository;
 use Illuminate\Support\Collection;
 
 /**
@@ -77,7 +76,7 @@ trait InteractWithSearch
             SortableFilter::uriKey() => SortableFilter::class,
         ])->get($type);
 
-        if (!is_subclass_of($base, Filter::class)) {
+        if (! is_subclass_of($base, Filter::class)) {
             return collect([]);
         }
 
@@ -92,8 +91,8 @@ trait InteractWithSearch
             }
 
             return $type instanceof Filter
-                ? tap($type, fn( $filter) => $filter->column = $filter->column ?? $column)
-                : tap(new $base, function ( $filter) use ($column, $type) {
+                ? tap($type, fn ($filter) => $filter->column = $filter->column ?? $column)
+                : tap(new $base, function ($filter) use ($column, $type) {
                     $filter->type = $type;
                     $filter->column = $column;
                 });

--- a/src/Traits/InteractWithSearch.php
+++ b/src/Traits/InteractWithSearch.php
@@ -2,6 +2,13 @@
 
 namespace Binaryk\LaravelRestify\Traits;
 
+use Binaryk\LaravelRestify\Filter;
+use Binaryk\LaravelRestify\Filters\MatchFilter;
+use Binaryk\LaravelRestify\Filters\SearchableFilter;
+use Binaryk\LaravelRestify\Filters\SortableFilter;
+use Binaryk\LaravelRestify\Repositories\Repository;
+use Illuminate\Support\Collection;
+
 /**
  * @author Eduard Lupacescu <eduard.lupacescu@binarcode.com>
  */
@@ -54,5 +61,42 @@ trait InteractWithSearch
         return empty(static::$sort)
             ? [static::newModel()->getQualifiedKeyName()]
             : static::$sort;
+    }
+
+    public static function collectFilters($type): Collection
+    {
+        $filters = collect([
+            SearchableFilter::uriKey() => static::getSearchableFields(),
+            MatchFilter::uriKey() => static::getMatchByFields(),
+            SortableFilter::uriKey() => static::getOrderByFields(),
+        ])->get($type);
+
+        $base = collect([
+            SearchableFilter::uriKey() => SearchableFilter::class,
+            MatchFilter::uriKey() => MatchFilter::class,
+            SortableFilter::uriKey() => SortableFilter::class,
+        ])->get($type);
+
+        if (!is_subclass_of($base, Filter::class)) {
+            return collect([]);
+        }
+
+        return collect($filters)->map(function ($type, $column) use ($base) {
+            if (is_numeric($column)) {
+                /*
+                 * This will handle for example searchables/sortables, where the definition is:
+                 * $search = ['title']
+                 * */
+                $column = $type;
+                $type = null;
+            }
+
+            return $type instanceof Filter
+                ? tap($type, fn( $filter) => $filter->column = $filter->column ?? $column)
+                : tap(new $base, function ( $filter) use ($column, $type) {
+                    $filter->type = $type;
+                    $filter->column = $column;
+                });
+        })->values();
     }
 }

--- a/tests/Actions/PerformActionsControllerTest.php
+++ b/tests/Actions/PerformActionsControllerTest.php
@@ -30,8 +30,8 @@ class PerformActionsControllerTest extends IntegrationTest
                 'data',
             ]);
 
-        $this->assertEquals(2, PublishPostAction::$applied[0][0]->id);
-        $this->assertEquals(1, PublishPostAction::$applied[0][1]->id);
+        $this->assertEquals(1, PublishPostAction::$applied[0][0]->id);
+        $this->assertEquals(2, PublishPostAction::$applied[0][1]->id);
     }
 
     public function test_cannot_apply_a_show_action_to_index()

--- a/tests/Controllers/RepositoryFilterControllerTest.php
+++ b/tests/Controllers/RepositoryFilterControllerTest.php
@@ -88,39 +88,6 @@ class RepositoryFilterControllerTest extends IntegrationTest
             ->assertJsonCount(2, 'data');
     }
 
-    public function test_available_filters_contains_repository_key()
-    {
-        PostRepository::$match = [
-            'title' => 'text',
-        ];
-
-        PostRepository::$sort = [
-            'title',
-        ];
-
-        PostRepository::$search = [
-            'id',
-            'title',
-        ];
-
-        $response = $this->getJson('posts/filters?only=matches,sortables,searchables')->assertJsonFragment([
-            'repository_key' => 'posts',
-        ]);
-
-        $this->getJson('posts/filters?only=matches')->assertJsonFragment([
-            'repository_key' => 'posts',
-        ]);
-
-
-        $this->getJson('posts/filters?only=sortables')->assertJsonFragment([
-            'repository_key' => 'posts',
-        ]);
-
-        $this->getJson('posts/filters?only=searchables')->assertJsonFragment([
-            'repository_key' => 'posts',
-        ]);
-    }
-
     public function test_value_filter_doesnt_require_value()
     {
         factory(Post::class)->create(['is_active' => false]);

--- a/tests/Controllers/RepositoryFilterControllerTest.php
+++ b/tests/Controllers/RepositoryFilterControllerTest.php
@@ -88,6 +88,39 @@ class RepositoryFilterControllerTest extends IntegrationTest
             ->assertJsonCount(2, 'data');
     }
 
+    public function test_available_filters_contains_repository_key()
+    {
+        PostRepository::$match = [
+            'title' => 'text',
+        ];
+
+        PostRepository::$sort = [
+            'title',
+        ];
+
+        PostRepository::$search = [
+            'id',
+            'title',
+        ];
+
+        $response = $this->getJson('posts/filters?only=matches,sortables,searchables')->assertJsonFragment([
+            'repository_key' => 'posts',
+        ]);
+
+        $this->getJson('posts/filters?only=matches')->assertJsonFragment([
+            'repository_key' => 'posts',
+        ]);
+
+
+        $this->getJson('posts/filters?only=sortables')->assertJsonFragment([
+            'repository_key' => 'posts',
+        ]);
+
+        $this->getJson('posts/filters?only=searchables')->assertJsonFragment([
+            'repository_key' => 'posts',
+        ]);
+    }
+
     public function test_value_filter_doesnt_require_value()
     {
         factory(Post::class)->create(['is_active' => false]);
@@ -101,7 +134,7 @@ class RepositoryFilterControllerTest extends IntegrationTest
 
         $response = $this
             ->withoutExceptionHandling()
-            ->getJson('posts?filters='.$filters)
+            ->getJson('posts?filters=' . $filters)
             ->assertStatus(200);
 
         $this->assertCount(1, $response->json('data'));
@@ -123,7 +156,7 @@ class RepositoryFilterControllerTest extends IntegrationTest
 
         $response = $this
             ->withoutExceptionHandling()
-            ->getJson('posts?filters='.$filters)
+            ->getJson('posts?filters=' . $filters)
             ->assertStatus(200);
 
         $this->assertCount(1, $response->json('data'));
@@ -143,7 +176,7 @@ class RepositoryFilterControllerTest extends IntegrationTest
 
         $response = $this
             ->withExceptionHandling()
-            ->getJson('posts?filters='.$filters)
+            ->getJson('posts?filters=' . $filters)
             ->assertStatus(200);
 
         $this->assertCount(1, $response->json('data'));

--- a/tests/Controllers/RepositoryFilterControllerTest.php
+++ b/tests/Controllers/RepositoryFilterControllerTest.php
@@ -101,7 +101,7 @@ class RepositoryFilterControllerTest extends IntegrationTest
 
         $response = $this
             ->withoutExceptionHandling()
-            ->getJson('posts?filters=' . $filters)
+            ->getJson('posts?filters='.$filters)
             ->assertStatus(200);
 
         $this->assertCount(1, $response->json('data'));
@@ -123,7 +123,7 @@ class RepositoryFilterControllerTest extends IntegrationTest
 
         $response = $this
             ->withoutExceptionHandling()
-            ->getJson('posts?filters=' . $filters)
+            ->getJson('posts?filters='.$filters)
             ->assertStatus(200);
 
         $this->assertCount(1, $response->json('data'));
@@ -143,7 +143,7 @@ class RepositoryFilterControllerTest extends IntegrationTest
 
         $response = $this
             ->withExceptionHandling()
-            ->getJson('posts?filters=' . $filters)
+            ->getJson('posts?filters='.$filters)
             ->assertStatus(200);
 
         $this->assertCount(1, $response->json('data'));

--- a/tests/Feature/Filters/FilterDefinitionTest.php
+++ b/tests/Feature/Filters/FilterDefinitionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Feature\Filters;
+
+use Binaryk\LaravelRestify\Filters\MatchFilter;
+use Binaryk\LaravelRestify\Filters\SearchableFilter;
+use Binaryk\LaravelRestify\Filters\SortableFilter;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
+use Binaryk\LaravelRestify\Tests\IntegrationTest;
+
+class FilterDefinitionTest extends IntegrationTest
+{
+    public function test_filters_can_have_definition()
+    {
+        PostRepository::$match = [
+            'title' => 'string',
+            'user_id' => MatchFilter::make()
+                ->setType('int')
+                ->setRelatedRepositoryKey(UserRepository::uriKey())
+        ];
+
+        PostRepository::$search = [
+            'title' => SearchableFilter::make()->setType('string'),
+        ];
+
+        PostRepository::$sort = [
+            'id' => SortableFilter::make()->setType('int'),
+            'title',
+        ];
+
+        $this->getJson('posts/filters?only=matches,searchables,sortables')
+            ->assertJsonFragment([
+                'related_repository_key' => 'users',
+            ]);
+    }
+}

--- a/tests/Feature/Filters/FilterDefinitionTest.php
+++ b/tests/Feature/Filters/FilterDefinitionTest.php
@@ -17,7 +17,7 @@ class FilterDefinitionTest extends IntegrationTest
             'title' => 'string',
             'user_id' => MatchFilter::make()
                 ->setType('int')
-                ->setRelatedRepositoryKey(UserRepository::uriKey())
+                ->setRelatedRepositoryKey(UserRepository::uriKey()),
         ];
 
         PostRepository::$search = [

--- a/tests/Feature/RepositorySearchServiceTest.php
+++ b/tests/Feature/RepositorySearchServiceTest.php
@@ -3,6 +3,9 @@
 namespace Binaryk\LaravelRestify\Tests\Feature;
 
 use Binaryk\LaravelRestify\Contracts\RestifySearchable;
+use Binaryk\LaravelRestify\Filters\MatchFilter;
+use Binaryk\LaravelRestify\Filters\SearchableFilter;
+use Binaryk\LaravelRestify\Filters\SortableFilter;
 use Binaryk\LaravelRestify\Services\Search\RepositorySearchService;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
@@ -54,6 +57,64 @@ class RepositorySearchServiceTest extends IntegrationTest
 
         $this->getJson('users?-id=1,2,3')
             ->assertJsonCount(1, 'data');
+    }
+
+    public function test_match_definition_hit_filter_method()
+    {
+        factory(User::class, 4)->create();
+
+        UserRepository::$match = [
+            'id' => MatchFilter::make()->setType(RestifySearchable::MATCH_ARRAY)
+        ];
+
+        $this->getJson('users?id=1,2,3')
+            ->assertJsonCount(3, 'data');
+
+        $this->getJson('users?-id=1,2,3')
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_can_search_using_filter_searchable_definition()
+    {
+        factory(User::class, 4)->create([
+            'name' => 'John Doe',
+        ]);
+
+        factory(User::class, 4)->create([
+            'name' => 'wew',
+        ]);
+
+        UserRepository::$search = [
+            'name' => SearchableFilter::make()
+        ];
+
+        $this->getJson('users?search=John')
+            ->assertJsonCount(4, 'data');
+    }
+
+    public function test_can_order_using_filter_sortable_definition()
+    {
+        factory(User::class)->create([
+            'name' => 'Zoro',
+        ]);
+
+        factory(User::class)->create([
+            'name' => 'Alisa',
+        ]);
+
+        UserRepository::$sort = [
+            'name' => SortableFilter::make()->setColumn('name')
+        ];
+
+        $this->assertSame('Alisa', $this->getJson('users?sort=name')
+        ->json('data.0.attributes.name'));
+        $this->assertSame('Zoro', $this->getJson('users?sort=name')
+        ->json('data.1.attributes.name'));
+
+        $this->assertSame('Zoro', $this->getJson('users?sort=-name')
+        ->json('data.0.attributes.name'));
+        $this->assertSame('Alisa', $this->getJson('users?sort=-name')
+            ->json('data.1.attributes.name'));
     }
 
     public function test_can_match_closure()


### PR DESCRIPTION
4.2.0

# Added

### Match definition

You can implement a match filter definition, and specify for example related repository:

```php
  public static $match = [
        'title' => 'string',
        'user_id' => MatchFilter::make()
            ->setType('int')
            ->setRelatedRepositoryKey(UserRepository::uriKey()),
];
```
When you will list this filter (with `posts/filters?only=matches`), you will get: 

```json
  {
      "class": "Binaryk\LaravelRestify\Filters\MatchFilter"
      "key": "matches"
      "type": "string"
      "column": "title"
      "options": []
    },
    {
      "class": "Binaryk\LaravelRestify\Filters\MatchFilter"
      "key": "matches"
      "type": "int"
      "column": "user_id"
      "options": []
      "related_repository_key": "users"
      "related_repository_url": "//users"
    }
```