### PR TITLE
Sorting by belongs to.

### DIFF
--- a/src/Eager/RelatedCollection.php
+++ b/src/Eager/RelatedCollection.php
@@ -22,23 +22,23 @@ class RelatedCollection extends Collection
 
     public function forEager(RestifyRequest $request): self
     {
-        return $this->filter(fn($value, $key) => $value instanceof EagerField)
-            ->filter(fn(Field $field) => $field->authorize($request))
+        return $this->filter(fn ($value, $key) => $value instanceof EagerField)
+            ->filter(fn (Field $field) => $field->authorize($request))
             ->unique('attribute');
     }
 
     public function mapIntoSortable(RestifyRequest $request): self
     {
-        return $this->filter(fn(EagerField $field) => $field->isSortable())
+        return $this->filter(fn (EagerField $field) => $field->isSortable())
             //Now we support only belongs to sort from related.
-            ->filter(fn(EagerField $field) => $field instanceof BelongsTo)
-            ->map(fn(BelongsTo $field) => SortableFilter::make()->usingBelongsTo($field));
+            ->filter(fn (EagerField $field) => $field instanceof BelongsTo)
+            ->map(fn (BelongsTo $field) => SortableFilter::make()->usingBelongsTo($field));
     }
 
     public function inRequest(RestifyRequest $request): self
     {
         return $this
-            ->filter(fn($field, $key) => in_array($key, str_getcsv($request->input('related'))))
+            ->filter(fn ($field, $key) => in_array($key, str_getcsv($request->input('related'))))
             ->unique();
     }
 
@@ -52,6 +52,6 @@ class RelatedCollection extends Collection
     public function authorized(RestifyRequest $request)
     {
         return $this->intoAssoc()
-            ->filter(fn($key, $value) => $key instanceof EagerField ? $key->authorize($request) : true);
+            ->filter(fn ($key, $value) => $key instanceof EagerField ? $key->authorize($request) : true);
     }
 }

--- a/src/Fields/EagerField.php
+++ b/src/Fields/EagerField.php
@@ -4,6 +4,8 @@ namespace Binaryk\LaravelRestify\Fields;
 
 use Binaryk\LaravelRestify\Repositories\Repository;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 
@@ -63,5 +65,28 @@ class EagerField extends Field
         }
 
         return $this;
+    }
+
+    public function getRelation(Repository $repository): Relation
+    {
+        return $repository->resource->newQuery()
+            ->getRelation($this->relation);
+    }
+
+    public function getRelatedModel(Repository $repository): ?Model
+    {
+        return $this->getRelation($repository)->getRelated();
+    }
+
+    public function getRelatedKey(Repository $repository): string
+    {
+        return $repository->resource->qualifyColumn(
+            $this->getRelation($repository)->getRelated()->getForeignKey()
+        );
+    }
+
+    public function getQualifiedKey(Repository $repository): string
+    {
+        return $this->getRelation($repository)->getRelated()->getQualifiedKeyName();
     }
 }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -121,6 +121,13 @@ class Field extends OrganicField implements JsonSerializable
     public $label;
 
     /**
+     * Indicates if the field should be sortable.
+     *
+     * @var bool
+     */
+    public $sortable = false;
+
+    /**
      * Create a new field.
      *
      * @param string|callable|null $attribute
@@ -395,7 +402,43 @@ class Field extends OrganicField implements JsonSerializable
     }
 
     /**
-     * Resolve the field's value for display.
+     * Determine if the attribute is computed.
+     *
+     * @return bool
+     */
+    public function computed()
+    {
+        return (is_callable($this->attribute) && ! is_string($this->attribute)) ||
+            is_callable($this->computedCallback) || $this->attribute == 'Computed';
+    }
+
+    /**
+     * Specify that this attribute should be sortable.
+     *
+     * @param  bool  $value
+     * @return $this
+     */
+    public function sortable($value = true)
+    {
+        if (! $this->computed()) {
+            $this->sortable = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Indicates if this attribute is sortable.
+     *
+     * @return bool
+     */
+    public function isSortable()
+    {
+        return $this->sortable;
+    }
+
+    /**
+     * Resolve the attribute's value for display.
      *
      * @param mixed $repository
      * @param string|null $attribute

--- a/src/Filters/SortableFilter.php
+++ b/src/Filters/SortableFilter.php
@@ -33,7 +33,7 @@ class SortableFilter extends Filter
         }
 
         if (isset($this->belongsToField)) {
-            if (!$this->belongsToField->authorize($request)) {
+            if (! $this->belongsToField->authorize($request)) {
                 return $query;
             }
 
@@ -64,7 +64,7 @@ class SortableFilter extends Filter
 
     public function getEager(): ?EagerField
     {
-        if (!isset($this->belongsToField)) {
+        if (! isset($this->belongsToField)) {
             return null;
         }
 
@@ -97,8 +97,9 @@ class SortableFilter extends Filter
 
     public function syncDirection(string $direction = null): self
     {
-        if (!is_null($direction) && in_array($direction, ['asc', 'desc'])) {
+        if (! is_null($direction) && in_array($direction, ['asc', 'desc'])) {
             $this->direction = $direction;
+
             return $this;
         }
 

--- a/src/Filters/SortableFilter.php
+++ b/src/Filters/SortableFilter.php
@@ -2,19 +2,129 @@
 
 namespace Binaryk\LaravelRestify\Filters;
 
+use Binaryk\LaravelRestify\Fields\BelongsTo;
+use Binaryk\LaravelRestify\Fields\EagerField;
 use Binaryk\LaravelRestify\Filter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
 
 class SortableFilter extends Filter
 {
     public static $uriKey = 'sortables';
 
+    public string $direction = 'asc';
+
+    private BelongsTo $belongsToField;
+
+    private Closure $resolver;
+
+    /**
+     * @param RestifyRequest $request
+     * @param Builder $query
+     * @param $direction
+     * @return false|mixed
+     */
     public function filter(RestifyRequest $request, $query, $direction)
     {
-        $query->orderBy($this->column,
-            $direction === '-'
-                ? 'desc'
-                : 'asc'
-        );
+        if (isset($this->resolver) && is_callable($this->resolver)) {
+            return call_user_func($this->resolver, $request, $query, $direction);
+        }
+
+        if (isset($this->belongsToField)) {
+            if (!$this->belongsToField->authorize($request)) {
+                return $query;
+            }
+
+            // This approach could be rewritten using join.
+            $query->orderBy($this->belongsToField->getRelatedModel($this->repository)::select('name')
+                ->whereColumn(
+                    $this->belongsToField->getQualifiedKey($this->repository),
+                    $this->belongsToField->getRelatedKey($this->repository))
+                ->orderBy($this->getColumn(), $direction)
+                ->take(1),
+                $direction
+            );
+
+            return $query;
+        }
+
+        $query->orderBy($this->column, $direction);
+    }
+
+    public function usingBelongsTo(BelongsTo $field)
+    {
+        $this->belongsToField = $field;
+
+//        $this->setColumn($field->attam ) //todo
+
+        return $this;
+    }
+
+    public function getEager(): ?EagerField
+    {
+        if (!isset($this->belongsToField)) {
+            return null;
+        }
+
+        return $this->belongsToField;
+    }
+
+    public function hasEager(): bool
+    {
+        return isset($this->belongsToField) && $this->belongsToField instanceof EagerField;
+    }
+
+    public function asc(): self
+    {
+        $this->direction = 'asc';
+
+        return $this;
+    }
+
+    public function desc(): self
+    {
+        $this->direction = 'desc';
+
+        return $this;
+    }
+
+    public function direction(): string
+    {
+        return $this->direction;
+    }
+
+    public function syncDirection(string $direction = null): self
+    {
+        if (!is_null($direction) && in_array($direction, ['asc', 'desc'])) {
+            $this->direction = $direction;
+            return $this;
+        }
+
+        if (Str::startsWith($this->column, '-')) {
+            $this->desc();
+
+            $this->column = Str::after($this->column, '-');
+
+            return $this;
+        }
+
+        if (Str::startsWith($this->column, '+')) {
+            $this->asc();
+
+            $this->column = Str::after($this->column, '+');
+
+            return $this;
+        }
+
+        return $this->asc();
+    }
+
+    public function usingClosure(Closure $closure): self
+    {
+        $this->resolver = $closure;
+
+        return $this;
     }
 }

--- a/src/Services/Search/RepositorySearchService.php
+++ b/src/Services/Search/RepositorySearchService.php
@@ -9,14 +9,13 @@ use Binaryk\LaravelRestify\Filters\SortableFilter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Binaryk\LaravelRestify\Repositories\Matchable;
 use Binaryk\LaravelRestify\Repositories\Repository;
-use Binaryk\LaravelRestify\Sort\SortCollection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
 class RepositorySearchService extends Searchable
 {
     /**
-     * @var Repository $repository
+     * @var Repository
      */
     protected $repository;
 
@@ -40,15 +39,15 @@ class RepositorySearchService extends Searchable
         foreach ($this->repository->getMatchByFields() as $key => $type) {
             $negation = false;
 
-            if ($request->has('-' . $key)) {
+            if ($request->has('-'.$key)) {
                 $negation = true;
             }
 
-            if (! $request->has($negation ? '-' . $key : $key) && ! data_get($extra, "match.$key")) {
+            if (! $request->has($negation ? '-'.$key : $key) && ! data_get($extra, "match.$key")) {
                 continue;
             }
 
-            $match = $request->input($negation ? '-' . $key : $key, data_get($extra, "match.$key"));
+            $match = $request->input($negation ? '-'.$key : $key, data_get($extra, "match.$key"));
 
             if ($negation) {
                 $key = Str::after($key, '-');
@@ -176,12 +175,12 @@ class RepositorySearchService extends Searchable
 
     protected function applyIndexQuery(RestifyRequest $request, Repository $repository)
     {
-        return fn($query) => $repository::indexQuery($request, $query);
+        return fn ($query) => $repository::indexQuery($request, $query);
     }
 
     protected function applyMainQuery(RestifyRequest $request, Repository $repository)
     {
-        return fn($query) => $repository::mainQuery($request, $query->with($repository::getWiths()));
+        return fn ($query) => $repository::mainQuery($request, $query->with($repository::getWiths()));
     }
 
     protected function applyFilters(RestifyRequest $request, Repository $repository, $query)
@@ -212,7 +211,7 @@ class RepositorySearchService extends Searchable
                     return $matchingFilter;
                 })
                 ->filter()
-                ->each(fn(Filter $filter) => $filter->filter($request, $query, $filter->value));
+                ->each(fn (Filter $filter) => $filter->filter($request, $query, $filter->value));
         }
 
         return $query;

--- a/src/Sort/SortCollection.php
+++ b/src/Sort/SortCollection.php
@@ -2,17 +2,13 @@
 
 namespace Binaryk\LaravelRestify\Sort;
 
-use Binaryk\LaravelRestify\Fields\EagerField;
-use Binaryk\LaravelRestify\Fields\Field;
 use Binaryk\LaravelRestify\Filter;
 use Binaryk\LaravelRestify\Filters\SortableFilter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
 use Exception;
-use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 class SortCollection extends Collection
 {
@@ -38,20 +34,20 @@ class SortCollection extends Collection
 
     public function hydrateRepository(Repository $repository): self
     {
-        return $this->map(fn(Filter $filter) => $filter->setRepository($repository));
+        return $this->map(fn (Filter $filter) => $filter->setRepository($repository));
     }
 
     public function allowed(RestifyRequest $request, Repository $repository)
     {
         $collection = static::make($repository::getOrderByFields());
 
-        return $this->filter(fn(SortableFilter $filter) => $collection->contains('column', '=', $filter->column));
+        return $this->filter(fn (SortableFilter $filter) => $collection->contains('column', '=', $filter->column));
     }
 
     public function hydrateDefinition(Repository $repository): SortCollection
     {
-        return $this->map(function(SortableFilter $filter) use ($repository) {
-            if (!array_key_exists($filter->column, $repository::getOrderByFields())) {
+        return $this->map(function (SortableFilter $filter) use ($repository) {
+            if (! array_key_exists($filter->column, $repository::getOrderByFields())) {
                 return $filter;
             }
 
@@ -67,17 +63,16 @@ class SortCollection extends Collection
 
             throw new Exception("Invalid argument to {$filter->column} sort in repository.");
         });
-
     }
 
     public function forEager(RestifyRequest $request): self
     {
-        return $this->filter(fn(SortableFilter $filter) => $filter->hasEager())
+        return $this->filter(fn (SortableFilter $filter) => $filter->hasEager())
             ->unique('column');
     }
 
     public function normalize()
     {
-        return $this->map(fn(SortableFilter $filter) => $filter->syncDirection());
+        return $this->map(fn (SortableFilter $filter) => $filter->syncDirection());
     }
 }

--- a/src/Sort/SortCollection.php
+++ b/src/Sort/SortCollection.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Sort;
+
+use Binaryk\LaravelRestify\Fields\EagerField;
+use Binaryk\LaravelRestify\Fields\Field;
+use Binaryk\LaravelRestify\Filter;
+use Binaryk\LaravelRestify\Filters\SortableFilter;
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Binaryk\LaravelRestify\Repositories\Repository;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class SortCollection extends Collection
+{
+    public function __construct($items = [])
+    {
+        $unified = [];
+
+        foreach ($items as $key => $item) {
+            $queryKey = is_numeric($key) ? $item : $key;
+            $definition = $item instanceof Filter
+                ? $item
+                : SortableFilter::make();
+
+            $definition->setColumn(
+                $definition->column ?? $queryKey
+            );
+
+            $unified[] = $definition;
+        }
+
+        parent::__construct($unified);
+    }
+
+    public function hydrateRepository(Repository $repository): self
+    {
+        return $this->map(fn(Filter $filter) => $filter->setRepository($repository));
+    }
+
+    public function allowed(RestifyRequest $request, Repository $repository)
+    {
+        $collection = static::make($repository::getOrderByFields());
+
+        return $this->filter(fn(SortableFilter $filter) => $collection->contains('column', '=', $filter->column));
+    }
+
+    public function hydrateDefinition(Repository $repository): SortCollection
+    {
+        return $this->map(function(SortableFilter $filter) use ($repository) {
+            if (!array_key_exists($filter->column, $repository::getOrderByFields())) {
+                return $filter;
+            }
+
+            $definition = Arr::get($repository::getOrderByFields(), $filter->getColumn());
+
+            if (is_callable($definition)) {
+                return $filter->usingClosure($definition);
+            }
+
+            if ($definition instanceof SortableFilter) {
+                return $definition->syncDirection($filter->direction());
+            }
+
+            throw new Exception("Invalid argument to {$filter->column} sort in repository.");
+        });
+
+    }
+
+    public function forEager(RestifyRequest $request): self
+    {
+        return $this->filter(fn(SortableFilter $filter) => $filter->hasEager())
+            ->unique('column');
+    }
+
+    public function normalize()
+    {
+        return $this->map(fn(SortableFilter $filter) => $filter->syncDirection());
+    }
+}

--- a/src/Traits/InteractWithSearch.php
+++ b/src/Traits/InteractWithSearch.php
@@ -40,7 +40,7 @@ trait InteractWithSearch
      */
     public static function getRelated()
     {
-        return static::$related ?? [];
+        return static::related();
     }
 
     public static function related(): array

--- a/src/Traits/InteractWithSearch.php
+++ b/src/Traits/InteractWithSearch.php
@@ -7,11 +7,11 @@ use Binaryk\LaravelRestify\Filter;
 use Binaryk\LaravelRestify\Filters\MatchFilter;
 use Binaryk\LaravelRestify\Filters\SearchableFilter;
 use Binaryk\LaravelRestify\Filters\SortableFilter;
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Binaryk\LaravelRestify\Repositories\Repository;
+use Binaryk\LaravelRestify\Sort\SortCollection;
 use Illuminate\Support\Collection;
 
-/**
- * @author Eduard Lupacescu <eduard.lupacescu@binarcode.com>
- */
 trait InteractWithSearch
 {
     use AuthorizableModels;
@@ -27,18 +27,23 @@ trait InteractWithSearch
             : static::$search;
     }
 
-    /**
-     * @return array
-     */
     public static function getWiths()
     {
         return static::$withs ?? [];
     }
 
     /**
+     * Use 'related' instead.
+     *
      * @return array
+     * @deprecated
      */
     public static function getRelated()
+    {
+        return static::$related ?? [];
+    }
+
+    public static function related(): array
     {
         return static::$related ?? [];
     }
@@ -60,12 +65,27 @@ trait InteractWithSearch
 
     /**
      * @return array
+     * @deprecated
      */
     public static function getOrderByFields()
+    {
+        return static::sorts();
+    }
+
+    public static function sorts(): array
     {
         return empty(static::$sort)
             ? [static::newModel()->getQualifiedKeyName()]
             : static::$sort;
+    }
+
+    public static function collectSorts(RestifyRequest $request, Repository $repository): SortCollection
+    {
+        return SortCollection::make(explode(',', $request->input('sort', '')))
+            ->normalize()
+            ->allowed($request, $repository)
+            ->hydrateDefinition($repository)
+            ->hydrateRepository($repository);
     }
 
     public static function collectFilters($type): Collection
@@ -82,7 +102,7 @@ trait InteractWithSearch
             SortableFilter::uriKey() => SortableFilter::class,
         ])->get($type);
 
-        if (! is_subclass_of($base, Filter::class)) {
+        if (!is_subclass_of($base, Filter::class)) {
             return collect([]);
         }
 
@@ -97,7 +117,7 @@ trait InteractWithSearch
             }
 
             return $type instanceof Filter
-                ? tap($type, fn ($filter) => $filter->column = $filter->column ?? $column)
+                ? tap($type, fn($filter) => $filter->column = $filter->column ?? $column)
                 : tap(new $base, function ($filter) use ($column, $type) {
                     $filter->type = $type;
                     $filter->column = $column;

--- a/src/Traits/InteractWithSearch.php
+++ b/src/Traits/InteractWithSearch.php
@@ -102,7 +102,7 @@ trait InteractWithSearch
             SortableFilter::uriKey() => SortableFilter::class,
         ])->get($type);
 
-        if (!is_subclass_of($base, Filter::class)) {
+        if (! is_subclass_of($base, Filter::class)) {
             return collect([]);
         }
 
@@ -117,7 +117,7 @@ trait InteractWithSearch
             }
 
             return $type instanceof Filter
-                ? tap($type, fn($filter) => $filter->column = $filter->column ?? $column)
+                ? tap($type, fn ($filter) => $filter->column = $filter->column ?? $column)
                 : tap(new $base, function ($filter) use ($column, $type) {
                     $filter->type = $type;
                     $filter->column = $column;

--- a/tests/Actions/PerformActionsControllerTest.php
+++ b/tests/Actions/PerformActionsControllerTest.php
@@ -19,7 +19,7 @@ class PerformActionsControllerTest extends IntegrationTest
     {
         $post = $this->mockPosts(1, 2);
 
-        $this->post('posts/action?action='.(new PublishPostAction())->uriKey(), [
+        $this->post('posts/action?action=' . (new PublishPostAction())->uriKey(), [
             'repositories' => [
                 $post->first()->id,
                 $post->last()->id,
@@ -30,8 +30,9 @@ class PerformActionsControllerTest extends IntegrationTest
                 'data',
             ]);
 
-        $this->assertEquals(1, PublishPostAction::$applied[0][0]->id);
-        $this->assertEquals(2, PublishPostAction::$applied[0][1]->id);
+        // Repositories are sorted desc by primary key.
+        $this->assertEquals(2, PublishPostAction::$applied[0][0]->id);
+        $this->assertEquals(1, PublishPostAction::$applied[0][1]->id);
     }
 
     public function test_cannot_apply_a_show_action_to_index()
@@ -41,7 +42,7 @@ class PerformActionsControllerTest extends IntegrationTest
         $_SERVER['actions.posts.invalidate'] = true;
         $_SERVER['actions.posts.publish.onlyOnShow'] = true;
 
-        $this->post('posts/action?action='.(new PublishPostAction())->uriKey(), [
+        $this->post('posts/action?action=' . (new PublishPostAction())->uriKey(), [
             'repositories' => [
                 $post->first()->id,
                 $post->last()->id,
@@ -57,7 +58,7 @@ class PerformActionsControllerTest extends IntegrationTest
     {
         $users = $this->mockUsers();
 
-        $this->post('users/'.$users->first()->id.'/action?action='.(new ActivateAction)->uriKey())
+        $this->post('users/' . $users->first()->id . '/action?action=' . (new ActivateAction)->uriKey())
             ->assertSuccessful()
             ->assertJsonStructure([
                 'data',
@@ -68,7 +69,7 @@ class PerformActionsControllerTest extends IntegrationTest
 
     public function test_could_perform_standalone_action()
     {
-        $this->post('users/action?action='.(new DisableProfileAction())->uriKey())
+        $this->post('users/action?action=' . (new DisableProfileAction())->uriKey())
             ->assertSuccessful()
             ->assertJsonStructure([
                 'data',

--- a/tests/Actions/PerformActionsControllerTest.php
+++ b/tests/Actions/PerformActionsControllerTest.php
@@ -19,7 +19,7 @@ class PerformActionsControllerTest extends IntegrationTest
     {
         $post = $this->mockPosts(1, 2);
 
-        $this->post('posts/action?action=' . (new PublishPostAction())->uriKey(), [
+        $this->post('posts/action?action='.(new PublishPostAction())->uriKey(), [
             'repositories' => [
                 $post->first()->id,
                 $post->last()->id,
@@ -42,7 +42,7 @@ class PerformActionsControllerTest extends IntegrationTest
         $_SERVER['actions.posts.invalidate'] = true;
         $_SERVER['actions.posts.publish.onlyOnShow'] = true;
 
-        $this->post('posts/action?action=' . (new PublishPostAction())->uriKey(), [
+        $this->post('posts/action?action='.(new PublishPostAction())->uriKey(), [
             'repositories' => [
                 $post->first()->id,
                 $post->last()->id,
@@ -58,7 +58,7 @@ class PerformActionsControllerTest extends IntegrationTest
     {
         $users = $this->mockUsers();
 
-        $this->post('users/' . $users->first()->id . '/action?action=' . (new ActivateAction)->uriKey())
+        $this->post('users/'.$users->first()->id.'/action?action='.(new ActivateAction)->uriKey())
             ->assertSuccessful()
             ->assertJsonStructure([
                 'data',
@@ -69,7 +69,7 @@ class PerformActionsControllerTest extends IntegrationTest
 
     public function test_could_perform_standalone_action()
     {
-        $this->post('users/action?action=' . (new DisableProfileAction())->uriKey())
+        $this->post('users/action?action='.(new DisableProfileAction())->uriKey())
             ->assertSuccessful()
             ->assertJsonStructure([
                 'data',

--- a/tests/Controllers/RepositoryIndexControllerTest.php
+++ b/tests/Controllers/RepositoryIndexControllerTest.php
@@ -65,19 +65,17 @@ class RepositoryIndexControllerTest extends IntegrationTest
 
         factory(Post::class)->create(['title' => 'zzz']);
 
-        $response = $this
-            ->getJson('posts?sort=-title')
+        $response = $this->getJson('posts?sort=-title')
             ->assertOk();
 
         $this->assertEquals('zzz', $response->json('data.0.attributes.title'));
         $this->assertEquals('aaa', $response->json('data.1.attributes.title'));
 
-        $response = $this
-            ->getJson('posts?order=-title')
+        $response = $this->getJson('posts?sort=title')
             ->assertOk();
 
-        $this->assertEquals('zzz', $response->json('data.1.attributes.title'));
         $this->assertEquals('aaa', $response->json('data.0.attributes.title'));
+        $this->assertEquals('zzz', $response->json('data.1.attributes.title'));
     }
 
     public function test_repository_with_relations()
@@ -136,7 +134,7 @@ class RepositoryIndexControllerTest extends IntegrationTest
             });
         });
 
-        $response = $this->getJson(CompanyRepository::uriKey().'?related=users.posts')
+        $response = $this->getJson(CompanyRepository::uriKey() . '?related=users.posts')
             ->assertOk();
 
         $this->assertCount(1, $response->json('data.0.relationships.users'));

--- a/tests/Controllers/RepositoryIndexControllerTest.php
+++ b/tests/Controllers/RepositoryIndexControllerTest.php
@@ -134,7 +134,7 @@ class RepositoryIndexControllerTest extends IntegrationTest
             });
         });
 
-        $response = $this->getJson(CompanyRepository::uriKey() . '?related=users.posts')
+        $response = $this->getJson(CompanyRepository::uriKey().'?related=users.posts')
             ->assertOk();
 
         $this->assertCount(1, $response->json('data.0.relationships.users'));

--- a/tests/Feature/Filters/FilterDefinitionTest.php
+++ b/tests/Feature/Filters/FilterDefinitionTest.php
@@ -7,14 +7,12 @@ use Binaryk\LaravelRestify\Filters\MatchFilter;
 use Binaryk\LaravelRestify\Filters\SearchableFilter;
 use Binaryk\LaravelRestify\Filters\SortableFilter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
-use Binaryk\LaravelRestify\Tests\Fields\PostWithUserRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
 use Binaryk\LaravelRestify\Tests\IntegrationTest;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Arr;
 
 class FilterDefinitionTest extends IntegrationTest
 {
@@ -70,7 +68,7 @@ class FilterDefinitionTest extends IntegrationTest
     public function test_can_filter_using_belongs_to_field()
     {
         PostRepository::$related = [
-            'user' => BelongsTo::make('user', 'user', UserRepository::class)
+            'user' => BelongsTo::make('user', 'user', UserRepository::class),
         ];
 
         PostRepository::$sort = [
@@ -87,16 +85,16 @@ class FilterDefinitionTest extends IntegrationTest
         factory(Post::class)->create([
             'user_id' => factory(User::class)->create([
                 'name' => 'Zez',
-            ])
+            ]),
         ]);
 
         factory(Post::class)->create([
             'user_id' => factory(User::class)->create([
                 'name' => 'Ame',
-            ])
+            ]),
         ]);
 
-        $json = $this->getJson(PostRepository::uriKey() . "?related=user&sort=-users.name")->json();
+        $json = $this->getJson(PostRepository::uriKey().'?related=user&sort=-users.name')->json();
 
         $this->assertSame(
             'Zez',

--- a/tests/Feature/Filters/FilterDefinitionTest.php
+++ b/tests/Feature/Filters/FilterDefinitionTest.php
@@ -2,12 +2,19 @@
 
 namespace Binaryk\LaravelRestify\Tests\Feature\Filters;
 
+use Binaryk\LaravelRestify\Fields\BelongsTo;
 use Binaryk\LaravelRestify\Filters\MatchFilter;
 use Binaryk\LaravelRestify\Filters\SearchableFilter;
 use Binaryk\LaravelRestify\Filters\SortableFilter;
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Binaryk\LaravelRestify\Tests\Fields\PostWithUserRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
 use Binaryk\LaravelRestify\Tests\IntegrationTest;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
 
 class FilterDefinitionTest extends IntegrationTest
 {
@@ -46,7 +53,6 @@ class FilterDefinitionTest extends IntegrationTest
         ];
 
         $this->getJson('posts/filters?only=matches')
-            ->dump()
             ->assertJsonStructure([
                 'data' => [
                     [
@@ -59,5 +65,47 @@ class FilterDefinitionTest extends IntegrationTest
                     ],
                 ],
             ]);
+    }
+
+    public function test_can_filter_using_belongs_to_field()
+    {
+        PostRepository::$related = [
+            'user' => BelongsTo::make('user', 'user', UserRepository::class)
+        ];
+
+        PostRepository::$sort = [
+            'users.name' => SortableFilter::make()->usingBelongsTo(
+                BelongsTo::make('user', 'user', UserRepository::class),
+            )
+            /*function (RestifyRequest $request, Builder $builder, $direction) {
+                    $builder->join('users', 'posts.user_id', '=', 'users.id')
+                        ->select('posts.*')
+                        ->orderBy('users.name', $direction);
+            }*/,
+        ];
+
+        factory(Post::class)->create([
+            'user_id' => factory(User::class)->create([
+                'name' => 'Zez',
+            ])
+        ]);
+
+        factory(Post::class)->create([
+            'user_id' => factory(User::class)->create([
+                'name' => 'Ame',
+            ])
+        ]);
+
+        $json = $this->getJson(PostRepository::uriKey() . "?related=user&sort=-users.name")->json();
+
+        $this->assertSame(
+            'Zez',
+            data_get($json, 'data.0.relationships.user.attributes.name')
+        );
+
+        $this->assertSame(
+            'Ame',
+            data_get($json, 'data.1.relationships.user.attributes.name')
+        );
     }
 }

--- a/tests/Feature/RepositorySearchServiceTest.php
+++ b/tests/Feature/RepositorySearchServiceTest.php
@@ -107,12 +107,12 @@ class RepositorySearchServiceTest extends IntegrationTest
         ];
 
         $this->assertSame('Alisa', $this->getJson('users?sort=name')
-        ->json('data.0.attributes.name'));
-        $this->assertSame('Zoro', $this->getJson('users?sort=name')
-        ->json('data.1.attributes.name'));
+            ->json('data.0.attributes.name'));
 
+        $this->assertSame('Zoro', $this->getJson('users?sort=name')
+            ->json('data.1.attributes.name'));
         $this->assertSame('Zoro', $this->getJson('users?sort=-name')
-        ->json('data.0.attributes.name'));
+            ->json('data.0.attributes.name'));
         $this->assertSame('Alisa', $this->getJson('users?sort=-name')
             ->json('data.1.attributes.name'));
     }


### PR DESCRIPTION
Sometimes you may need to sort by a `belongsTo` relationship. This become a breeze with Restify. Firstly you have to
instruct your sort to use a relationship:

```php
// PostRepository
use Binaryk\LaravelRestify\Fields\BelongsTo;
use Binaryk\LaravelRestify\Filters\SortableFilter;

public static function sorts(): array
{
    return [
        'users.name' => SortableFilter::make()
            ->setColumn('users.name')
            ->usingBelongsTo(
                BelongsTo::make('user', 'user', UserRepository::class),
        )
    ];
}
```