### PR TITLE
Fixing belongs to filtering.

### DIFF
--- a/src/Filters/SortableFilter.php
+++ b/src/Filters/SortableFilter.php
@@ -53,11 +53,9 @@ class SortableFilter extends Filter
         $query->orderBy($this->column, $direction);
     }
 
-    public function usingBelongsTo(BelongsTo $field)
+    public function usingBelongsTo(BelongsTo $field): self
     {
         $this->belongsToField = $field;
-
-//        $this->setColumn($field->attam ) //todo
 
         return $this;
     }

--- a/src/Sort/SortCollection.php
+++ b/src/Sort/SortCollection.php
@@ -58,7 +58,6 @@ class SortCollection extends Collection
 
             $definition = Arr::get($repository::getOrderByFields(), $filter->getColumn());
 
-
             if (is_callable($definition)) {
                 return $filter->usingClosure($definition);
             }

--- a/src/Sort/SortCollection.php
+++ b/src/Sort/SortCollection.php
@@ -22,6 +22,11 @@ class SortCollection extends Collection
                 ? $item
                 : SortableFilter::make();
 
+            if ($queryKey instanceof SortableFilter) {
+                $unified[] = $queryKey;
+                continue;
+            }
+
             $definition->setColumn(
                 $definition->column ?? $queryKey
             );
@@ -34,7 +39,7 @@ class SortCollection extends Collection
 
     public function hydrateRepository(Repository $repository): self
     {
-        return $this->map(fn (Filter $filter) => $filter->setRepository($repository));
+        return $this->each(fn (Filter $filter) => $filter->setRepository($repository));
     }
 
     public function allowed(RestifyRequest $request, Repository $repository)
@@ -52,6 +57,7 @@ class SortCollection extends Collection
             }
 
             $definition = Arr::get($repository::getOrderByFields(), $filter->getColumn());
+
 
             if (is_callable($definition)) {
                 return $filter->usingClosure($definition);
@@ -73,6 +79,6 @@ class SortCollection extends Collection
 
     public function normalize()
     {
-        return $this->map(fn (SortableFilter $filter) => $filter->syncDirection());
+        return $this->each(fn (SortableFilter $filter) => $filter->syncDirection());
     }
 }

--- a/src/Traits/InteractWithSearch.php
+++ b/src/Traits/InteractWithSearch.php
@@ -98,8 +98,8 @@ trait InteractWithSearch
     {
         return SortCollection::make(explode(',', $request->input('sort', '')))
             ->normalize()
-            ->allowed($request, $repository)
             ->hydrateDefinition($repository)
+            ->allowed($request, $repository)
             ->hydrateRepository($repository);
     }
 
@@ -117,7 +117,7 @@ trait InteractWithSearch
             SortableFilter::uriKey() => SortableFilter::class,
         ])->get($type);
 
-        if (! is_subclass_of($base, Filter::class)) {
+        if (!is_subclass_of($base, Filter::class)) {
             return collect([]);
         }
 
@@ -132,7 +132,7 @@ trait InteractWithSearch
             }
 
             return $type instanceof Filter
-                ? tap($type, fn ($filter) => $filter->column = $filter->column ?? $column)
+                ? tap($type, fn($filter) => $filter->column = $filter->column ?? $column)
                 : tap(new $base, function ($filter) use ($column, $type) {
                     $filter->type = $type;
                     $filter->column = $column;

--- a/src/Traits/InteractWithSearch.php
+++ b/src/Traits/InteractWithSearch.php
@@ -117,7 +117,7 @@ trait InteractWithSearch
             SortableFilter::uriKey() => SortableFilter::class,
         ])->get($type);
 
-        if (!is_subclass_of($base, Filter::class)) {
+        if (! is_subclass_of($base, Filter::class)) {
             return collect([]);
         }
 
@@ -132,7 +132,7 @@ trait InteractWithSearch
             }
 
             return $type instanceof Filter
-                ? tap($type, fn($filter) => $filter->column = $filter->column ?? $column)
+                ? tap($type, fn ($filter) => $filter->column = $filter->column ?? $column)
                 : tap(new $base, function ($filter) use ($column, $type) {
                     $filter->type = $type;
                     $filter->column = $column;

--- a/tests/Feature/Filters/FilterDefinitionTest.php
+++ b/tests/Feature/Filters/FilterDefinitionTest.php
@@ -6,13 +6,11 @@ use Binaryk\LaravelRestify\Fields\BelongsTo;
 use Binaryk\LaravelRestify\Filters\MatchFilter;
 use Binaryk\LaravelRestify\Filters\SearchableFilter;
 use Binaryk\LaravelRestify\Filters\SortableFilter;
-use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
 use Binaryk\LaravelRestify\Tests\IntegrationTest;
-use Illuminate\Database\Eloquent\Builder;
 
 class FilterDefinitionTest extends IntegrationTest
 {
@@ -74,7 +72,7 @@ class FilterDefinitionTest extends IntegrationTest
         PostRepository::$sort = [
             'users.attributes.name' => SortableFilter::make()->setColumn('users.name')->usingBelongsTo(
                 BelongsTo::make('user', 'user', UserRepository::class),
-            )
+            ),
         ];
 
         factory(Post::class)->create([
@@ -91,7 +89,7 @@ class FilterDefinitionTest extends IntegrationTest
 
         $json = $this
             ->withoutExceptionHandling()
-            ->getJson(PostRepository::uriKey() . '?related=user&sort=-users.attributes.name')
+            ->getJson(PostRepository::uriKey().'?related=user&sort=-users.attributes.name')
             ->json();
 
         $this->assertSame(

--- a/tests/Feature/Filters/FilterDefinitionTest.php
+++ b/tests/Feature/Filters/FilterDefinitionTest.php
@@ -72,14 +72,9 @@ class FilterDefinitionTest extends IntegrationTest
         ];
 
         PostRepository::$sort = [
-            'users.name' => SortableFilter::make()->usingBelongsTo(
+            'users.attributes.name' => SortableFilter::make()->setColumn('users.name')->usingBelongsTo(
                 BelongsTo::make('user', 'user', UserRepository::class),
             )
-            /*function (RestifyRequest $request, Builder $builder, $direction) {
-                    $builder->join('users', 'posts.user_id', '=', 'users.id')
-                        ->select('posts.*')
-                        ->orderBy('users.name', $direction);
-            }*/,
         ];
 
         factory(Post::class)->create([
@@ -94,7 +89,9 @@ class FilterDefinitionTest extends IntegrationTest
             ]),
         ]);
 
-        $json = $this->getJson(PostRepository::uriKey().'?related=user&sort=-users.name')
+        $json = $this
+            ->withoutExceptionHandling()
+            ->getJson(PostRepository::uriKey() . '?related=user&sort=-users.attributes.name')
             ->json();
 
         $this->assertSame(


### PR DESCRIPTION
# Fixed

- Sorting using BelongsTo field type. So now you can have: 

```
// PostRepository

public static function sorts(): array
{
  return [
            'users.attributes.name' => SortableFilter::make()->setColumn('users.name')->usingBelongsTo(
                BelongsTo::make('user', 'user', UserRepository::class),
            )
 ];
}
```

And frontend can filter your posts by `users.name` using: 

`api/restify/posts?sort=users.attributes.name`.