### PR TITLE
Use matches from the query only.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -116,13 +116,6 @@ return [
         'related' => \Binaryk\LaravelRestify\Repositories\Casts\RelatedCast::class,
     ],
 
-    'search' => [
-        /*
-        | Allow Restify to check the post payload in order to receive matchable filters.
-        */
-        'matchable_using_post_payload' => true,
-    ],
-
     /*
     |--------------------------------------------------------------------------
     | Restify Logs

--- a/src/Filters/MatchesCollection.php
+++ b/src/Filters/MatchesCollection.php
@@ -60,12 +60,7 @@ class MatchesCollection extends Collection
                 }
             }
 
-            if (! config('restify.search.matchable_using_post_payload')) {
-                return (bool) ($request->query("-{$filter->column()}") || $request->query($filter->column()));
-            }
-
-
-            return $request->has("-{$filter->column()}") || $request->has($filter->column());
+            return (bool) ($request->query("-{$filter->column()}") || $request->query($filter->column()));
         });
     }
 


### PR DESCRIPTION
- fix: Fixing query matches. (#439)
- fix: Use only query params for matching.
