### PR TITLE
Boolean Match not triggered when falsy value is sent

### DIFF
--- a/src/Filters/MatchesCollection.php
+++ b/src/Filters/MatchesCollection.php
@@ -60,7 +60,8 @@ class MatchesCollection extends Collection
                 }
             }
 
-            return (bool) ($request->query("-{$filter->column()}") || $request->query($filter->column()));
+            return ! is_null($request->query("-{$filter->column()}"))
+                || ! is_null($request->query($filter->column()));
         });
     }
 


### PR DESCRIPTION
Fixes https://github.com/BinarCode/laravel-restify/issues/453

The problem was with the value for the `query` param... `show_inactive=0` would result in `(bool) 0` => `false`; altho `show_inactive` param was in query 