### PR TITLE
[7.x] Cache policies

### DIFF
--- a/config/restify.php
+++ b/config/restify.php
@@ -136,7 +136,7 @@ return [
 
     'repositories' => [
         /*
-        | Specify either to serialize index meta (policy) information or not. For performance reasons we recommend to disable it.
+        | Specify either to serialize index meta (policy) information or not. For performance reasons we recommend disabling it.
         */
         'serialize_index_meta' => false,
 
@@ -154,10 +154,7 @@ return [
         'policies' => [
             'enabled' => false,
 
-            /*
-            | ttl in seconds
-            */
-            'ttl' => 5 * 60,
+            'ttl' => 5 * 60, // seconds
         ],
     ],
 ];

--- a/config/restify.php
+++ b/config/restify.php
@@ -145,4 +145,19 @@ return [
         */
         'serialize_show_meta' => true,
     ],
+
+    'cache' => [
+        /*
+        | Specify the cache configuration for the resources policies.
+        | When enabled, methods from the policy will be cached for the active user.
+        */
+        'policies' => [
+            'enabled' => false,
+
+            /*
+            | ttl in seconds
+            */
+            'ttl' => 5 * 60,
+        ],
+    ],
 ];

--- a/docs-v2/content/en/performance/performance.md
+++ b/docs-v2/content/en/performance/performance.md
@@ -1,0 +1,38 @@
+---
+title: Performance
+menuTitle: Performance
+description: Performance
+category: Performance
+position: 14
+---
+
+## Policy Caching
+
+When loading a large number of models, Restify will check each policy method as `show` or `allowRestify` (including for all relations) before serializing them.
+
+In order to improve performance, Restify caches the policies. You simply have to enable the caching by setting the `restify.cache.policies.enabled` property to `true` in the `restify.php` configuration file:
+
+```php
+'cache' => [
+    'policies' => [
+        'enabled' => true,
+        'ttl' => 5 * 60, // seconds
+    ],
+],
+```
+
+The caching is tight to the current authenticated user so if another user is logged in, the cache will be hydrated for the new user once again.
+
+## Disable index meta
+
+Index meta are policy information related to what actions are allowed on a resource for a specific user. However, if you don't need this information, you can disable the index meta by setting the `restify.repositories.serialize_index_meta` property to `false` in the `restify.php` configuration file:
+
+```php
+'repositories' => [
+    'serialize_index_meta' => false,
+    
+    'serialize_show_meta' => true,
+],
+```
+
+This will give your application a boost, especially when loading a large amount of resources or relations.

--- a/docs-v2/content/en/testing/testing.md
+++ b/docs-v2/content/en/testing/testing.md
@@ -3,7 +3,7 @@ title: Testing Repositories
 menuTitle: Testing Repositories
 description: Unlike traditional static method calls, repositories may be mocked. This provides a great advantage over traditional static methods and grants you the same testability you would have if you were using dependency injection. When testing, you may often want to mock a call to a Restify repository in one of your controllers. For example, consider the following controller action
 category: Testing
-position: 13
+position: 15
 ---
 
 ```php

--- a/src/Cache/PolicyCache.php
+++ b/src/Cache/PolicyCache.php
@@ -11,7 +11,7 @@ class PolicyCache
 {
     public static function enabled(): bool
     {
-        return config("restify.cache.policies.enabled", false);
+        return config('restify.cache.policies.enabled', false);
     }
 
     public static function keyForAllowRestify(string $repositoryKey): string

--- a/src/Cache/PolicyCache.php
+++ b/src/Cache/PolicyCache.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Cache;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class PolicyCache
+{
+    public static function enabled(): bool
+    {
+        return config("restify.cache.policies.enabled", false);
+    }
+
+    public static function keyForAllowRestify(string $repositoryKey): string
+    {
+        $user = app(Request::class)->user();
+
+        return "restify.policy.allowRestify.repository-$repositoryKey.user-".$user?->getKey();
+    }
+
+    public static function keyForPolicyMethods(string $repositoryKey, string $policyMethod, string|int|null $modelKey): string
+    {
+        $modelKey = $modelKey ?? Str::random();
+
+        $user = app(Request::class)->user();
+
+        return "restify.policy.$policyMethod.repository-$repositoryKey.resource-$modelKey.user-".$user?->getKey();
+    }
+
+    public static function resolve(string $key, callable|Closure $data): mixed
+    {
+        if (Cache::has($key)) {
+            return Cache::get($key);
+        }
+
+        Cache::put($key, $data = $data(), config('restify.cache.policies.ttl', 60));
+
+        return $data;
+    }
+}

--- a/src/Cache/RestifyCache.php
+++ b/src/Cache/RestifyCache.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Cache;
+
+class RestifyCache
+{
+    public static function enabled(string $for): bool
+    {
+        return config("restify.cache.{$for}.enabled", false);
+    }
+}

--- a/src/Eager/Related.php
+++ b/src/Eager/Related.php
@@ -72,8 +72,6 @@ class Related implements JsonSerializable
     {
         $request->related()->resolved($this->uniqueIdentifierForRepository($repository));
 
-        ray($request->related()->resolvedRelationships);
-
         if (is_callable($this->resolverCallback)) {
             $this->value = call_user_func($this->resolverCallback, $request, $repository);
 

--- a/src/Traits/AuthorizableModels.php
+++ b/src/Traits/AuthorizableModels.php
@@ -3,12 +3,10 @@
 namespace Binaryk\LaravelRestify\Traits;
 
 use Binaryk\LaravelRestify\Cache\PolicyCache;
-use Binaryk\LaravelRestify\Cache\RestifyCache;
 use Binaryk\LaravelRestify\Repositories\Repository;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -22,12 +20,12 @@ trait AuthorizableModels
 {
     public static function authorizable(): bool
     {
-        return !is_null(Gate::getPolicyFor(static::newModel()));
+        return ! is_null(Gate::getPolicyFor(static::newModel()));
     }
 
     public static function authorizedToUseRepository(Request $request): bool
     {
-        if (!static::authorizable()) {
+        if (! static::authorizable()) {
             return false;
         }
 
@@ -37,7 +35,7 @@ trait AuthorizableModels
                 : false;
         };
 
-        if (!PolicyCache::enabled()) {
+        if (! PolicyCache::enabled()) {
             return $resolver();
         }
 
@@ -64,7 +62,7 @@ trait AuthorizableModels
      */
     public static function authorizeToStore(Request $request): void
     {
-        if (!static::authorizedToStore($request)) {
+        if (! static::authorizedToStore($request)) {
             throw new AuthorizationException('Unauthorized to store.');
         }
     }
@@ -74,7 +72,7 @@ trait AuthorizableModels
      */
     public static function authorizeToStoreBulk(Request $request): void
     {
-        if (!static::authorizedToStoreBulk($request)) {
+        if (! static::authorizedToStoreBulk($request)) {
             throw new AuthorizationException('Unauthorized to store bulk.');
         }
     }
@@ -107,7 +105,7 @@ trait AuthorizableModels
 
     public function authorizeToAttach(Request $request, $method, $model): bool
     {
-        if (!static::authorizable()) {
+        if (! static::authorizable()) {
             return false;
         }
 
@@ -127,7 +125,7 @@ trait AuthorizableModels
 
     public function authorizeToDetach(Request $request, $method, $model)
     {
-        if (!static::authorizable()) {
+        if (! static::authorizable()) {
             throw new AuthorizationException();
         }
 
@@ -189,7 +187,7 @@ trait AuthorizableModels
 
         return PolicyCache::resolve(
             PolicyCache::keyForPolicyMethods(static::uriKey(), $ability, $this->resource->getKey()),
-            fn() => Gate::check($ability, $this->resource)
+            fn () => Gate::check($ability, $this->resource)
         );
     }
 

--- a/tests/Feature/AuthorizableModelsTest.php
+++ b/tests/Feature/AuthorizableModelsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Feature;
+
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostPolicy;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
+use Binaryk\LaravelRestify\Tests\IntegrationTest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+
+class AuthorizableModelsTest extends IntegrationTest
+{
+    use RefreshDatabase;
+
+    public function test_can_cache_allowRestify_policy_so_its_called_once_per_user(): void
+    {
+        $this->partialMock(PostPolicy::class)
+            ->shouldReceive('allowRestify')
+            ->twice()
+            ->andReturn(false);
+
+        Gate::policy(Post::class, PostPolicy::class);
+
+        $_SERVER['restify.post.allowRestify'] = false;
+
+        $this->getJson(PostRepository::route())
+            ->assertForbidden();
+
+        $this->getJson(PostRepository::route())
+            ->assertForbidden();
+
+        $this->authenticate(User::factory()->state(['id' => 2])->create());
+
+        $this->getJson(PostRepository::route())
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/AuthorizableModelsTest.php
+++ b/tests/Feature/AuthorizableModelsTest.php
@@ -2,17 +2,30 @@
 
 namespace Binaryk\LaravelRestify\Tests\Feature;
 
+use Binaryk\LaravelRestify\Tests\Database\Factories\PostFactory;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostPolicy;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
 use Binaryk\LaravelRestify\Tests\IntegrationTest;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Gate;
 
 class AuthorizableModelsTest extends IntegrationTest
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('restify.cache.policies.enabled', true);
+
+        $_SERVER['restify.post.allowRestify'] = true;
+
+        Cache::flush();
+    }
 
     public function test_can_cache_allowRestify_policy_so_its_called_once_per_user(): void
     {
@@ -32,6 +45,78 @@ class AuthorizableModelsTest extends IntegrationTest
             ->assertForbidden();
 
         $this->authenticate(User::factory()->state(['id' => 2])->create());
+
+        $this->getJson(PostRepository::route())
+            ->assertForbidden();
+    }
+
+    public function test_can_cache_show_policy_so_its_called_once_per_user_per_model(): void
+    {
+        $this->partialMock(PostPolicy::class)
+            ->shouldReceive('show')
+            ->once()
+            ->andReturn(true);
+
+        Gate::policy(Post::class, PostPolicy::class);
+
+        $post = PostFactory::one();
+
+        $this->getJson(PostRepository::route($post->id))
+            ->assertOk();
+        $this->getJson(PostRepository::route($post->id))
+            ->assertOk();
+
+        // for 2 models and the same user it'll be called twice (once for each model)
+        $this->partialMock(PostPolicy::class)
+            ->shouldReceive('show')
+            ->twice()
+            ->andReturn(true);
+
+        PostFactory::many()->each(function (Post $post) {
+            $this->getJson(PostRepository::route($post->id))
+                ->assertOk();
+            $this->getJson(PostRepository::route($post->id))
+                ->assertOk();
+        });
+
+        // for 2 models and different users it'll be called 4 times (once for each model and user)
+        $this->partialMock(PostPolicy::class)
+            ->shouldReceive('show')
+            ->times(4)
+            ->andReturn(true);
+
+
+        $this->authenticate(User::factory()->create());
+        PostFactory::many()->each(function (Post $post) {
+            $this->getJson(PostRepository::route($post->id))
+                ->assertOk();
+            $this->getJson(PostRepository::route($post->id))
+                ->assertOk();
+        });
+
+        $this->authenticate(User::factory()->create());
+        PostFactory::many()->each(function (Post $post) {
+            $this->getJson(PostRepository::route($post->id))
+                ->assertOk();
+            $this->getJson(PostRepository::route($post->id))
+                ->assertOk();
+        });
+    }
+
+    public function test_can_disable_policies_cache(): void
+    {
+        config()->set('restify.cache.policies.enabled', false);
+
+        $this->partialMock(PostPolicy::class)
+            ->shouldReceive('allowRestify')
+            ->times(3)
+            ->andReturn(false);
+
+        $this->getJson(PostRepository::route())
+            ->assertForbidden();
+
+        $this->getJson(PostRepository::route())
+            ->assertForbidden();
 
         $this->getJson(PostRepository::route())
             ->assertForbidden();

--- a/tests/Feature/AuthorizableModelsTest.php
+++ b/tests/Feature/AuthorizableModelsTest.php
@@ -85,7 +85,6 @@ class AuthorizableModelsTest extends IntegrationTest
             ->times(4)
             ->andReturn(true);
 
-
         $this->authenticate(User::factory()->create());
         PostFactory::many()->each(function (Post $post) {
             $this->getJson(PostRepository::route($post->id))

--- a/tests/Fields/BelongsToFieldTest.php
+++ b/tests/Fields/BelongsToFieldTest.php
@@ -226,11 +226,11 @@ class BelongsToFieldTest extends IntegrationTest
             'include' => 'user[name]',
         ]))
             ->assertJson(
-            fn (AssertableJson $json) => $json
-            ->has('data.relationships.user.attributes.name')
-            ->missing('data.relationships.user.attributes.email')
-            ->etc()
-        );
+                fn (AssertableJson $json) => $json
+                ->has('data.relationships.user.attributes.name')
+                ->missing('data.relationships.user.attributes.email')
+                ->etc()
+            );
     }
 }
 

--- a/tests/Fields/BelongsToFieldTest.php
+++ b/tests/Fields/BelongsToFieldTest.php
@@ -220,9 +220,12 @@ class BelongsToFieldTest extends IntegrationTest
                 'user' => BelongsTo::make('user', UserRepository::class),
             ]);
 
+        $this->withoutExceptionHandling();
+
         $this->getJson(PostRepository::route($post->id, [
             'include' => 'user[name]',
-        ]))->assertJson(
+        ]))
+            ->assertJson(
             fn (AssertableJson $json) => $json
             ->has('data.relationships.user.attributes.name')
             ->missing('data.relationships.user.attributes.email')

--- a/tests/Fields/HasManyTest.php
+++ b/tests/Fields/HasManyTest.php
@@ -13,6 +13,7 @@ use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
 use Binaryk\LaravelRestify\Tests\IntegrationTest;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Testing\Fluent\AssertableJson;
 
@@ -192,6 +193,8 @@ class HasManyTest extends IntegrationTest
             ->assertJsonCount(0, 'data');
 
         $_SERVER['restify.post.allowRestify'] = false;
+
+        $this->authenticate(User::factory()->create());
 
         $this->getJson(UserWithPosts::route("$u->id/posts"))
             ->assertForbidden();

--- a/tests/Fixtures/User/User.php
+++ b/tests/Fixtures/User/User.php
@@ -39,6 +39,7 @@ class User extends Authenticatable implements Sanctumable, MustVerifyEmail
     public static $withs = ['posts'];
 
     protected $fillable = [
+        'id',
         'name',
         'email',
         'active',


### PR DESCRIPTION
This will enable policies to be cached by adding the configuration: 


```
  'cache' => [
      /*
      | Specify the cache configuration for the resources policies.
      | When enabled, methods from the policy will be cached for the active user.
      */
      'policies' => [
          'enabled' => true,

          /*
          | ttl in seconds
          */
          'ttl' => 5 * 60,
      ],
  ],
```