### PR TITLE
[7.x] Fixing cache enable option.

### DIFF
--- a/src/Cache/PolicyCache.php
+++ b/src/Cache/PolicyCache.php
@@ -32,6 +32,10 @@ class PolicyCache
 
     public static function resolve(string $key, callable|Closure $data): mixed
     {
+        if (! static::enabled()) {
+            return $data();
+        }
+
         if (Cache::has($key)) {
             return Cache::get($key);
         }

--- a/src/Traits/AuthorizableModels.php
+++ b/src/Traits/AuthorizableModels.php
@@ -35,13 +35,7 @@ trait AuthorizableModels
                 : false;
         };
 
-        if (! PolicyCache::enabled()) {
-            return $resolver();
-        }
-
-        $key = PolicyCache::keyForAllowRestify(static::uriKey());
-
-        return PolicyCache::resolve($key, $resolver);
+        return PolicyCache::resolve(PolicyCache::keyForAllowRestify(static::uriKey()), $resolver);
     }
 
     /**


### PR DESCRIPTION
## Fixed

- Cache enable option is considered during the policy methods check.