### PR TITLE
[7.x] Make testing route method more robust

### DIFF
--- a/src/Repositories/Concerns/Testing.php
+++ b/src/Repositories/Concerns/Testing.php
@@ -30,7 +30,7 @@ trait Testing
         }
 
         $route = implode('/', array_filter([
-            Restify::path(),
+            static::prefix() ?: Restify::path(),
             static::uriKey(),
             $path,
             $action ? 'actions' : null,

--- a/src/Repositories/Concerns/Testing.php
+++ b/src/Repositories/Concerns/Testing.php
@@ -16,8 +16,8 @@ trait Testing
 {
     public static function route(
         string|Model $path = null,
-        Action $action = null,
         array $query = [],
+        Action $action = null,
     ): string {
         if ($path instanceof Model) {
             $path = $path->getKey();

--- a/src/Repositories/Concerns/Testing.php
+++ b/src/Repositories/Concerns/Testing.php
@@ -5,8 +5,7 @@ namespace Binaryk\LaravelRestify\Repositories\Concerns;
 use Binaryk\LaravelRestify\Actions\Action;
 use Binaryk\LaravelRestify\Repositories\Repository;
 use Binaryk\LaravelRestify\Restify;
-use Illuminate\Support\Str;
-use Illuminate\Support\Stringable;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Trait Testing
@@ -15,21 +14,33 @@ use Illuminate\Support\Stringable;
  */
 trait Testing
 {
-    public static function route(string $path = null, array $query = []): Stringable
-    {
-        if (str($path)->startsWith('/')) {
-            $path = str($path)->replaceFirst('/', '')->toString();
+    public static function route(
+        string|Model $path = null,
+        Action $action = null,
+        array $query = [],
+    ): string {
+        if ($path instanceof Model) {
+            $path = $path->getKey();
         }
 
-        $base = (static::prefix() ?: Str::replaceFirst('//', '/', Restify::path())).'/'.static::uriKey();
+        $path = ltrim($path, '/');
 
-        $route = $path
-            ? $base.'/'.$path
-            : $base;
+        if ($action) {
+            $query['action'] = $action->uriKey();
+        }
 
-        return str(empty($query)
-            ? $route
-            : $route.'?'.http_build_query($query));
+        $route = implode('/', array_filter([
+            Restify::path(),
+            static::uriKey(),
+            $path,
+            $action ? 'actions' : null,
+        ]));
+
+        if (empty($query)) {
+            return $route;
+        }
+
+        return $route.'?'.http_build_query($query);
     }
 
     /**

--- a/src/Repositories/Concerns/Testing.php
+++ b/src/Repositories/Concerns/Testing.php
@@ -23,7 +23,7 @@ trait Testing
             $path = $path->getKey();
         }
 
-        $path = ltrim($path, '/');
+        $path = ltrim((string) $path, '/');
 
         if ($action) {
             $query['action'] = $action->uriKey();
@@ -48,11 +48,7 @@ trait Testing
      */
     public static function action(string $action, string|int $key = null): string
     {
-        $path = $key ? "$key/actions" : 'actions';
-
-        return static::route($path, [
-            'action' => app($action)->uriKey(),
-        ]);
+        return static::route($key, action: app($action));
     }
 
     public static function getter(string $getter, string|int $key = null): string

--- a/src/Restify.php
+++ b/src/Restify.php
@@ -65,10 +65,10 @@ class Restify
     public static function repositoryClassForPrefix(string $prefix): ?string
     {
         return collect(static::$repositories)->first(function ($value) use ($prefix) {
-            /** * @var Repository $value */
-            return str($prefix)->whenStartsWith('/', fn ($string) => $string->replaceFirst('/', ''))->contains(
-                $value::route()
-                    ->whenStartsWith('/', fn ($string) => $string->replaceFirst('/', '')),
+            /** @var Repository $value */
+            return str_contains(
+                ltrim($prefix, '/'),
+                ltrim($value::route(), '/')
             );
         });
     }

--- a/src/Services/Search/GlobalSearch.php
+++ b/src/Services/Search/GlobalSearch.php
@@ -50,7 +50,7 @@ class GlobalSearch
                     'title' => $instance->title(),
                     'subTitle' => $instance->subtitle(),
                     'repositoryId' => $model->getKey(),
-                    'link' => $repository::route($model->getKey()),
+                    'link' => $repository::route($model),
                 ];
             }
         }

--- a/tests/Actions/PerformActionControllerTest.php
+++ b/tests/Actions/PerformActionControllerTest.php
@@ -47,7 +47,8 @@ class PerformActionControllerTest extends IntegrationTest
         PostRepository::partialMock()
             ->shouldReceive('actions')
             ->andReturn([
-                new class () extends Action {
+                new class() extends Action
+                {
                     public static $uriKey = 'publish';
 
                     public function handle(Request $request, Collection $collection)

--- a/tests/Actions/PerformActionControllerTest.php
+++ b/tests/Actions/PerformActionControllerTest.php
@@ -47,8 +47,7 @@ class PerformActionControllerTest extends IntegrationTest
         PostRepository::partialMock()
             ->shouldReceive('actions')
             ->andReturn([
-                new class() extends Action
-                {
+                new class () extends Action {
                     public static $uriKey = 'publish';
 
                     public function handle(Request $request, Collection $collection)
@@ -60,7 +59,7 @@ class PerformActionControllerTest extends IntegrationTest
                 },
             ]);
 
-        $this->postJson(PostRepository::route('actions', ['action' => 'publish']), [
+        $this->postJson(PostRepository::route('actions', query: ['action' => 'publish']), [
             'repositories' => 'all',
         ])->assertOk()->assertJsonFragment([
             'fromHandle' => 0,

--- a/tests/Controllers/Index/IndexRelatedFeatureTest.php
+++ b/tests/Controllers/Index/IndexRelatedFeatureTest.php
@@ -37,7 +37,7 @@ class IndexRelatedFeatureTest extends IntegrationTest
                 'owner',
                 'users' => HasMany::make('users', UserRepository::class),
                 'extraData' => fn () => ['country' => 'Romania'],
-                'extraMeta' => new InvokableExtraMeta,
+                'extraMeta' => new InvokableExtraMeta(),
             ]);
 
         UserRepository::partialMock()
@@ -60,7 +60,7 @@ class IndexRelatedFeatureTest extends IntegrationTest
                 )
             )->create();
 
-        $this->withoutExceptionHandling()->getJson(CompanyRepository::route(null, [
+        $this->withoutExceptionHandling()->getJson(CompanyRepository::route(query: [
             'related' => 'users.companies.users, users.posts, users.roles, extraData, extraMeta, owner',
         ]))->assertJson(
             fn (AssertableJson $json) => $json
@@ -102,7 +102,8 @@ class IndexRelatedFeatureTest extends IntegrationTest
 
         $this->getJson(CommentRepository::route(query: [
             'related' => 'parent, children',
-        ]))->assertJson(fn (AssertableJson $json) => $json
+        ]))->assertJson(
+            fn (AssertableJson $json) => $json
             ->where('data.2.attributes.comment', 'Root comment')
             ->has('data.2.relationships.parent')
             ->missing('data.2.relationships.parent.relationships.parent')
@@ -180,7 +181,7 @@ class IndexRelatedFeatureTest extends IntegrationTest
 
         PostFactory::one();
 
-        $this->getJson(PostRepository::route(null, [
+        $this->getJson(PostRepository::route(query: [
             'related' => 'user',
         ]))->assertJson(
             fn (AssertableJson $json) => $json
@@ -206,7 +207,7 @@ class IndexRelatedFeatureTest extends IntegrationTest
             'name' => $owner = 'John Doe',
         ]))->create();
 
-        $this->getJson(PostRepository::route(null, [
+        $this->getJson(PostRepository::route(query: [
             'perPage' => 5,
             'related' => 'user',
             'sort' => 'id',

--- a/tests/Controllers/Index/RepositoryIndexControllerTest.php
+++ b/tests/Controllers/Index/RepositoryIndexControllerTest.php
@@ -30,7 +30,7 @@ class RepositoryIndexControllerTest extends IntegrationTest
                     ->etc()
             );
 
-        $this->getJson(PostRepository::route(null, [
+        $this->getJson(PostRepository::route(query: [
             'perPage' => 10,
         ]))->assertJson(
             fn (AssertableJson $json) => $json
@@ -38,7 +38,7 @@ class RepositoryIndexControllerTest extends IntegrationTest
                 ->etc()
         );
 
-        $this->getJson(PostRepository::route(null, [
+        $this->getJson(PostRepository::route(query: [
             'page[size]' => 10,
         ]))->assertJson(
             fn (AssertableJson $json) => $json
@@ -46,7 +46,7 @@ class RepositoryIndexControllerTest extends IntegrationTest
                 ->etc()
         );
 
-        $this->getJson(PostRepository::route(null, [
+        $this->getJson(PostRepository::route(query: [
             'perPage' => 10,
             'page' => '2',
         ]))->assertJson(
@@ -55,7 +55,7 @@ class RepositoryIndexControllerTest extends IntegrationTest
                 ->etc()
         );
 
-        $this->getJson(PostRepository::route(null, [
+        $this->getJson(PostRepository::route(query: [
             'page[size]' => 10,
             'page[number]' => 2,
         ]))->assertJson(
@@ -86,7 +86,7 @@ class RepositoryIndexControllerTest extends IntegrationTest
 
         PostRepository::$search = ['title'];
 
-        $this->getJson(PostRepository::route(null, [
+        $this->getJson(PostRepository::route(query: [
             'search' => 'code',
         ]))->assertJson(fn (AssertableJson $json) => $json->count('data', 2)->etc());
     }
@@ -106,7 +106,7 @@ class RepositoryIndexControllerTest extends IntegrationTest
             'title',
         ];
 
-        $this->getJson(PostRepository::route(null, [
+        $this->getJson(PostRepository::route(query: [
             'sort' => '-title',
         ]))->assertJson(
             fn (AssertableJson $json) => $json
@@ -115,7 +115,7 @@ class RepositoryIndexControllerTest extends IntegrationTest
                 ->etc()
         );
 
-        $this->getJson(PostRepository::route(null, [
+        $this->getJson(PostRepository::route(query: [
             'sort' => 'title',
         ]))->assertJson(
             fn (AssertableJson $json) => $json
@@ -138,7 +138,7 @@ class RepositoryIndexControllerTest extends IntegrationTest
             ])
         )->create();
 
-        $this->getJson(PostRepository::route(null, [
+        $this->getJson(PostRepository::route(query: [
             'related' => 'user',
         ]))->assertJson(
             fn (AssertableJson $json) => $json

--- a/tests/Controllers/RepositoryAttachControllerTest.php
+++ b/tests/Controllers/RepositoryAttachControllerTest.php
@@ -14,7 +14,6 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Testing\Fluent\AssertableJson;
-
 use function PHPUnit\Framework\assertInstanceOf;
 
 class RepositoryAttachControllerTest extends IntegrationTest

--- a/tests/Controllers/RepositoryAttachControllerTest.php
+++ b/tests/Controllers/RepositoryAttachControllerTest.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Testing\Fluent\AssertableJson;
+
 use function PHPUnit\Framework\assertInstanceOf;
 
 class RepositoryAttachControllerTest extends IntegrationTest
@@ -99,7 +100,7 @@ class RepositoryAttachControllerTest extends IntegrationTest
             $company->users()->attach($this->mockUsers()->first()->id);
         });
 
-        $this->getJson(CompanyRepository::route($company->id, [
+        $this->getJson(CompanyRepository::route($company->id, query: [
             'include' => 'users',
         ]))->assertOk()->assertJson(
             fn (AssertableJson $json) => $json

--- a/tests/Controllers/RepositoryDestroyControllerTest.php
+++ b/tests/Controllers/RepositoryDestroyControllerTest.php
@@ -25,7 +25,7 @@ class RepositoryDestroyControllerTest extends IntegrationTest
 
         $_SERVER['restify.post.delete'] = true;
 
-        $this->deleteJson(PostRepository::route($post->id), [
+        $this->deleteJson(PostRepository::route($post), [
             'title' => 'Updated title',
         ])
             ->assertStatus(204);
@@ -41,7 +41,7 @@ class RepositoryDestroyControllerTest extends IntegrationTest
 
         $_SERVER['restify.post.delete'] = false;
 
-        $this->deleteJson(PostRepository::route($post->id))->assertStatus(403);
+        $this->deleteJson(PostRepository::route($post))->assertStatus(403);
 
         $this->assertInstanceOf(Post::class, $post->refresh());
     }

--- a/tests/Controllers/RepositoryFilterControllerTest.php
+++ b/tests/Controllers/RepositoryFilterControllerTest.php
@@ -25,7 +25,7 @@ class RepositoryFilterControllerTest extends IntegrationTest
         ];
 
         $this->withoutExceptionHandling();
-        $this->getJson(PostRepository::route('filters', [
+        $this->getJson(PostRepository::route('filters', query: [
             'include' => 'matches,sortables,searchables',
         ]))
             // 5 custom filters
@@ -61,16 +61,16 @@ class RepositoryFilterControllerTest extends IntegrationTest
             'title',
         ];
 
-        $this->getJson(PostRepository::route('filters', [
+        $this->getJson(PostRepository::route('filters', query: [
             'only' => 'matches,sortables,searchables',
         ]))->assertJsonCount(4, 'data');
 
-        $this->getJson(PostRepository::route('filters', ['only' => 'matches']))
+        $this->getJson(PostRepository::route('filters', query: ['only' => 'matches']))
             ->assertJsonCount(1, 'data');
 
-        $this->getJson(PostRepository::route('filters', ['only' => 'sortables']))->assertJsonCount(1, 'data');
+        $this->getJson(PostRepository::route('filters', query: ['only' => 'sortables']))->assertJsonCount(1, 'data');
 
-        $this->getJson(PostRepository::route('filters', ['only' => 'searchables']))
+        $this->getJson(PostRepository::route('filters', query: ['only' => 'searchables']))
             ->assertJsonCount(2, 'data');
     }
 }

--- a/tests/Controllers/RepositoryPatchControllerTest.php
+++ b/tests/Controllers/RepositoryPatchControllerTest.php
@@ -28,7 +28,7 @@ class RepositoryPatchControllerTest extends IntegrationTest
                 field('description')->rules('required'),
             ]);
 
-        $this->patchJson(PostRepository::route($post->id), [
+        $this->patchJson(PostRepository::route($post), [
             'title' => 'Updated title.',
         ])->assertOk();
 

--- a/tests/Controllers/RepositoryUpdateControllerTest.php
+++ b/tests/Controllers/RepositoryUpdateControllerTest.php
@@ -23,7 +23,7 @@ class RepositoryUpdateControllerTest extends IntegrationTest
     {
         $post = Post::factory()->create();
 
-        $this->putJson(PostRepository::route($post->id), [
+        $this->putJson(PostRepository::route($post), [
             'title' => 'Updated title',
         ])->assertOk();
 
@@ -34,7 +34,7 @@ class RepositoryUpdateControllerTest extends IntegrationTest
     {
         $post = Post::factory()->create();
 
-        $this->putJson(PostRepository::route($post->id), [
+        $this->putJson(PostRepository::route($post), [
             'title' => 'Updated title',
         ])->assertOk();
 
@@ -49,7 +49,7 @@ class RepositoryUpdateControllerTest extends IntegrationTest
 
         $_SERVER['restify.post.update'] = false;
 
-        $this->putJson(PostRepository::route($post->id), [
+        $this->putJson(PostRepository::route($post), [
             'title' => 'Updated title',
         ])->assertStatus(403);
     }

--- a/tests/Controllers/Show/ShowRelatedFeatureTest.php
+++ b/tests/Controllers/Show/ShowRelatedFeatureTest.php
@@ -34,7 +34,7 @@ class ShowRelatedFeatureTest extends IntegrationTest
 
         $this->withoutExceptionHandling();
 
-        $this->getJson(CommentRepository::route($comment->id, [
+        $this->getJson(CommentRepository::route($comment, query: [
             'related' => 'user, post.user',
         ]))->assertJson(
             fn (AssertableJson $json) => $json
@@ -46,7 +46,7 @@ class ShowRelatedFeatureTest extends IntegrationTest
 
         app(RelatedDto::class)->reset();
 
-        $this->getJson(CommentRepository::route($comment->id, [
+        $this->getJson(CommentRepository::route($comment, query: [
             'related' => 'user, post',
         ]))->assertJson(
             fn (AssertableJson $json) => $json

--- a/tests/Feature/AuthorizableModelsTest.php
+++ b/tests/Feature/AuthorizableModelsTest.php
@@ -61,9 +61,9 @@ class AuthorizableModelsTest extends IntegrationTest
 
         $post = PostFactory::one();
 
-        $this->getJson(PostRepository::route($post->id))
+        $this->getJson(PostRepository::route($post))
             ->assertOk();
-        $this->getJson(PostRepository::route($post->id))
+        $this->getJson(PostRepository::route($post))
             ->assertOk();
 
         // for 2 models and the same user it'll be called twice (once for each model)
@@ -73,9 +73,9 @@ class AuthorizableModelsTest extends IntegrationTest
             ->andReturn(true);
 
         PostFactory::many()->each(function (Post $post) {
-            $this->getJson(PostRepository::route($post->id))
+            $this->getJson(PostRepository::route($post))
                 ->assertOk();
-            $this->getJson(PostRepository::route($post->id))
+            $this->getJson(PostRepository::route($post))
                 ->assertOk();
         });
 
@@ -87,17 +87,17 @@ class AuthorizableModelsTest extends IntegrationTest
 
         $this->authenticate(User::factory()->create());
         PostFactory::many()->each(function (Post $post) {
-            $this->getJson(PostRepository::route($post->id))
+            $this->getJson(PostRepository::route($post))
                 ->assertOk();
-            $this->getJson(PostRepository::route($post->id))
+            $this->getJson(PostRepository::route($post))
                 ->assertOk();
         });
 
         $this->authenticate(User::factory()->create());
         PostFactory::many()->each(function (Post $post) {
-            $this->getJson(PostRepository::route($post->id))
+            $this->getJson(PostRepository::route($post))
                 ->assertOk();
-            $this->getJson(PostRepository::route($post->id))
+            $this->getJson(PostRepository::route($post))
                 ->assertOk();
         });
     }

--- a/tests/Feature/Filters/AdvancedFilterTest.php
+++ b/tests/Feature/Filters/AdvancedFilterTest.php
@@ -34,7 +34,7 @@ class AdvancedFilterTest extends IntegrationTest
             'title',
         ];
 
-        $this->getJson(PostRepository::route('filters', [
+        $this->getJson(PostRepository::route('filters', query: [
             'only' => 'matches,searchables,sortables',
         ]))->assertJson(
             fn (AssertableJson $json) => $json
@@ -117,7 +117,7 @@ class AdvancedFilterTest extends IntegrationTest
             ],
         ], JSON_THROW_ON_ERROR));
 
-        $this->getJson(PostRepository::route(null, ['filters' => $filters]))
+        $this->getJson(PostRepository::route(query: ['filters' => $filters]))
             ->assertJsonCount(0, 'data');
     }
 
@@ -127,7 +127,7 @@ class AdvancedFilterTest extends IntegrationTest
         Post::factory(2)->create(['is_active' => true]);
 
         $this
-            ->getJson(PostRepository::route('filters', [
+            ->getJson(PostRepository::route('filters', query: [
                 'include' => 'matches',
             ]))
             ->assertOk()
@@ -167,7 +167,7 @@ class AdvancedFilterTest extends IntegrationTest
             ],
         ], JSON_THROW_ON_ERROR));
 
-        $this->getJson(PostRepository::route(null, ['filters' => $filters]))
+        $this->getJson(PostRepository::route(query: ['filters' => $filters]))
             ->assertOk()
             ->assertJsonCount(1, 'data');
     }

--- a/tests/Feature/Filters/MatchFilterTest.php
+++ b/tests/Feature/Filters/MatchFilterTest.php
@@ -16,7 +16,8 @@ class MatchFilterTest extends IntegrationTest
 {
     public function test_matchable_filter_has_key(): void
     {
-        $filter = new class () extends MatchFilter {
+        $filter = new class() extends MatchFilter
+        {
             public ?string $column = 'approved_at';
         };
 

--- a/tests/Feature/Filters/MatchFilterTest.php
+++ b/tests/Feature/Filters/MatchFilterTest.php
@@ -16,8 +16,7 @@ class MatchFilterTest extends IntegrationTest
 {
     public function test_matchable_filter_has_key(): void
     {
-        $filter = new class() extends MatchFilter
-        {
+        $filter = new class () extends MatchFilter {
             public ?string $column = 'approved_at';
         };
 
@@ -43,7 +42,7 @@ class MatchFilterTest extends IntegrationTest
             'title' => 'string',
         ];
 
-        $this->getJson(PostRepository::route('filters', [
+        $this->getJson(PostRepository::route('filters', query: [
             'only' => 'matches',
         ]))
             ->assertJsonStructure([

--- a/tests/Fields/BelongsToFieldTest.php
+++ b/tests/Fields/BelongsToFieldTest.php
@@ -47,7 +47,7 @@ class BelongsToFieldTest extends IntegrationTest
                 'user' => BelongsTo::make('user', UserRepository::class),
             ]);
 
-        $this->getJson(PostRepository::route($post->id, [
+        $this->getJson(PostRepository::route($post, query: [
             'related' => 'user',
         ]))
             ->assertJsonStructure([
@@ -62,7 +62,7 @@ class BelongsToFieldTest extends IntegrationTest
                 ],
             ]);
 
-        $relationships = $this->getJson(PostRepository::route($post->id))
+        $relationships = $this->getJson(PostRepository::route($post))
             ->json('data.relationships');
 
         $this->assertNull($relationships);
@@ -77,7 +77,7 @@ class BelongsToFieldTest extends IntegrationTest
         tap(Post::factory()->create([
             'user_id' => User::factory(),
         ]), function ($post) {
-            $this->getJson(PostWithUserRepository::route($post->id, [
+            $this->getJson(PostWithUserRepository::route($post, query: [
                 'related' => 'user',
             ]))->assertForbidden();
         });
@@ -92,7 +92,7 @@ class BelongsToFieldTest extends IntegrationTest
         tap(Post::factory()->create([
             'user_id' => null,
         ]), function ($post) {
-            $this->getJson(PostWithUserRepository::route($post->id, [
+            $this->getJson(PostWithUserRepository::route($post, query: [
                 'related' => 'user',
             ]))
                 ->assertJsonFragment([
@@ -181,7 +181,7 @@ class BelongsToFieldTest extends IntegrationTest
             'user_id' => User::factory(),
         ]), function ($post) {
             $newOwner = User::factory()->create();
-            $this->putJson(PostWithUserRepository::route($post->id), [
+            $this->putJson(PostWithUserRepository::route($post), [
                 'title' => 'Can change post owner.',
                 'user' => $newOwner->id,
             ])->assertOk();
@@ -201,7 +201,7 @@ class BelongsToFieldTest extends IntegrationTest
         ]), function ($post) {
             $firstOwnerId = $post->user->id;
             $newOwner = User::factory()->create();
-            $this->putJson(PostWithUserRepository::route($post->id), [
+            $this->putJson(PostWithUserRepository::route($post), [
                 'title' => 'Can change post owner.',
                 'user' => $newOwner->id,
             ])->assertForbidden();
@@ -222,7 +222,7 @@ class BelongsToFieldTest extends IntegrationTest
 
         $this->withoutExceptionHandling();
 
-        $this->getJson(PostRepository::route($post->id, [
+        $this->getJson(PostRepository::route($post, query: [
             'include' => 'user[name]',
         ]))
             ->assertJson(

--- a/tests/Fields/BelongsToManyFieldTest.php
+++ b/tests/Fields/BelongsToManyFieldTest.php
@@ -19,7 +19,7 @@ class BelongsToManyFieldTest extends IntegrationTest
             );
         });
 
-        $this->withoutExceptionHandling()->getJson(CompanyRepository::route($company->id, ['include' => 'users']))
+        $this->withoutExceptionHandling()->getJson(CompanyRepository::route($company, query: ['include' => 'users']))
             ->assertJsonStructure([
                 'data' => [
                     'relationships' => [
@@ -43,7 +43,7 @@ class BelongsToManyFieldTest extends IntegrationTest
                 'users' => BelongsToMany::make('users', UserRepository::class)->hideFromShow(),
             ]);
 
-        $this->getJson(CompanyRepository::route($company->id, ['include' => 'users']))
+        $this->getJson(CompanyRepository::route($company, query: ['include' => 'users']))
             ->assertJsonStructure([
                 'data' => [],
             ])->assertJsonMissing([

--- a/tests/Fields/FileTest.php
+++ b/tests/Fields/FileTest.php
@@ -139,7 +139,7 @@ class FileTest extends IntegrationTest
                 Image::make('avatar')->disk('customDisk')->storeAs('avatar.jpg')->deletable(true),
             ]);
 
-        $this->deleteJson(UserRepository::route($user.'/field/avatar'))
+        $this->deleteJson(UserRepository::route($user->getKey().'/field/avatar'))
             ->assertNoContent();
 
         Storage::disk('customDisk')->assertMissing('avatar.jpg');

--- a/tests/Fields/FileTest.php
+++ b/tests/Fields/FileTest.php
@@ -57,7 +57,7 @@ class FileTest extends IntegrationTest
 
         $user = $this->mockUsers()->first();
 
-        $this->postJson(UserRepository::route($user->getKey()), [
+        $this->postJson(UserRepository::route($user), [
             'avatar' => UploadedFile::fake()->image('image.jpg'),
         ])->assertOk()->assertJsonFragment([
             'avatar_original' => 'image.jpg',
@@ -93,7 +93,7 @@ class FileTest extends IntegrationTest
                     ->storeAs('avatar.jpg'),
             ]);
 
-        $this->deleteJson(UserRepository::route($user->getKey()))
+        $this->deleteJson(UserRepository::route($user))
             ->assertNoContent();
 
         Storage::disk('customDisk')->assertMissing('avatar.jpg');
@@ -116,7 +116,7 @@ class FileTest extends IntegrationTest
                 Image::make('avatar')->disk('customDisk')->storeAs('avatar.jpg'),
             ]);
 
-        $this->deleteJson(UserRepository::route($user->getKey()))
+        $this->deleteJson(UserRepository::route($user))
             ->assertNoContent();
 
         Storage::disk('customDisk')->assertExists('avatar.jpg');
@@ -139,7 +139,7 @@ class FileTest extends IntegrationTest
                 Image::make('avatar')->disk('customDisk')->storeAs('avatar.jpg')->deletable(true),
             ]);
 
-        $this->deleteJson(UserRepository::route($user->getKey().'/field/avatar'))
+        $this->deleteJson(UserRepository::route($user.'/field/avatar'))
             ->assertNoContent();
 
         Storage::disk('customDisk')->assertMissing('avatar.jpg');
@@ -162,7 +162,7 @@ class FileTest extends IntegrationTest
                 Image::make('avatar')->disk('customDisk')->storeAs('avatar.jpg')->deletable(false),
             ]);
 
-        $this->deleteJson(UserRepository::route($user->getKey().'/field/avatar'))
+        $this->deleteJson(UserRepository::route($user.'/field/avatar'))
             ->assertNotFound();
     }
 
@@ -180,7 +180,7 @@ class FileTest extends IntegrationTest
 
         $user = $this->mockUsers()->first();
 
-        $this->postJson(UserRepository::route($user->getKey()), [
+        $this->postJson(UserRepository::route($user), [
             'avatar' => UploadedFile::fake()->image('image.jpg'),
         ])->assertOk()->assertJsonFragment([
             'avatar' => '/storage/avatar.jpg',
@@ -208,7 +208,7 @@ class FileTest extends IntegrationTest
                 Image::make('avatar')->disk('customDisk')->storeAs('newAvatar.jpg')->prunable(),
             ]);
 
-        $this->postJson(UserRepository::route($user->getKey()), [
+        $this->postJson(UserRepository::route($user), [
             'avatar' => UploadedFile::fake()->image('image.jpg'),
         ])->assertOk()->assertJsonFragment([
             'avatar' => '/storage/newAvatar.jpg',

--- a/tests/Fields/HasManyTest.php
+++ b/tests/Fields/HasManyTest.php
@@ -44,7 +44,7 @@ class HasManyTest extends IntegrationTest
             'user_id' => $user->getKey(),
         ]);
 
-        $this->getJson(UserWithPosts::route($user->getKey(), [
+        $this->getJson(UserWithPosts::route($user, query: [
             'related' => 'posts',
         ]))->assertJsonStructure([
             'data' => [
@@ -70,7 +70,7 @@ class HasManyTest extends IntegrationTest
             'user_id' => $user->getKey(),
         ]);
 
-        $this->getJson(UserWithPosts::route($user->getKey(), ['related' => 'posts[title]']))
+        $this->getJson(UserWithPosts::route($user, query: ['related' => 'posts[title]']))
             ->assertJson(
                 fn (AssertableJson $json) => $json
                     ->where('data.relationships.posts.0.attributes.title', 'Title')
@@ -79,7 +79,7 @@ class HasManyTest extends IntegrationTest
 
         app(RelatedDto::class)->reset();
 
-        $this->getJson(UserWithPosts::route($user->getKey(), ['related' => 'posts[title|description]']))
+        $this->getJson(UserWithPosts::route($user, query: ['related' => 'posts[title|description]']))
             ->assertJson(
                 fn (AssertableJson $json) => $json
                     ->where('data.relationships.posts.0.attributes.title', 'Title')
@@ -94,7 +94,7 @@ class HasManyTest extends IntegrationTest
             $this->mockPosts($user->getKey(), 22);
         });
 
-        $this->getJson(UserWithPosts::route($user->getKey(), ['related' => 'posts', 'relatablePerPage' => 20]))
+        $this->getJson(UserWithPosts::route($user, query: ['related' => 'posts', 'relatablePerPage' => 20]))
             ->assertJsonCount(20, 'data.relationships.posts');
     }
 
@@ -107,7 +107,7 @@ class HasManyTest extends IntegrationTest
             $this->mockPosts($user->getKey(), 20);
         });
 
-        $this->getJson(UserWithPosts::route($user->getKey(), ['related' => 'posts']))
+        $this->getJson(UserWithPosts::route($user, query: ['related' => 'posts']))
             ->assertOk()
             ->assertJson(fn (AssertableJson $json) => $json->count('data.relationships.posts', 0)->etc());
     }
@@ -140,7 +140,7 @@ class HasManyTest extends IntegrationTest
                 HasMany::make('posts', PostRepository::class),
             ]);
 
-        $this->getJson(UserWithPosts::route("$u->id/posts", ['perPage' => 5]))
+        $this->getJson(UserWithPosts::route("$u->id/posts", query: ['perPage' => 5]))
             ->assertJsonCount(5, 'data');
     }
 
@@ -164,7 +164,7 @@ class HasManyTest extends IntegrationTest
                 HasMany::make('posts', PostRepository::class),
             ]);
 
-        $this->getJson(UserWithPosts::route("$u->id/posts", ['title' => 'wew']))
+        $this->getJson(UserWithPosts::route("$u->id/posts", query: ['title' => 'wew']))
             ->assertJsonCount(1, 'data');
     }
 

--- a/tests/Fields/HasOneFieldTest.php
+++ b/tests/Fields/HasOneFieldTest.php
@@ -41,7 +41,7 @@ class HasOneFieldTest extends IntegrationTest
     {
         $post = Post::factory()->create();
 
-        $this->getJson(UserWithPostRepository::route($post->user_id, ['include' => 'post']))->assertJsonStructure([
+        $this->getJson(UserWithPostRepository::route($post->user_id, query: ['include' => 'post']))->assertJsonStructure([
             'data' => [
                 'relationships' => [
                     'post',
@@ -61,7 +61,7 @@ class HasOneFieldTest extends IntegrationTest
         tap(Post::factory()->create([
             'user_id' => User::factory(),
         ]), function (Post $post) {
-            $this->postJson(UserWithPostRepository::route($post->user_id, [
+            $this->postJson(UserWithPostRepository::route($post->user_id, query: [
                 'include' => 'post',
             ]))->assertForbidden();
         });

--- a/tests/Fields/ImageTest.php
+++ b/tests/Fields/ImageTest.php
@@ -40,7 +40,7 @@ class ImageTest extends IntegrationTest
 
         $user = $this->mockUsers()->first();
 
-        $this->postJson(UserRepository::route($user->getKey()), [
+        $this->postJson(UserRepository::route($user), [
             'avatar' => UploadedFile::fake()->image('image.jpg'),
         ])->assertOk()->assertJsonFragment([
             'avatar' => '/storage/avatar.jpg',

--- a/tests/Fields/MorphOneFieldTest.php
+++ b/tests/Fields/MorphOneFieldTest.php
@@ -38,7 +38,7 @@ class MorphOneFieldTest extends IntegrationTest
 
         $relationships = $this
             ->withoutExceptionHandling()
-            ->getJson(PostWithMorphOneRepository::route($post->id, ['related' => 'user']))
+            ->getJson(PostWithMorphOneRepository::route($post, query: ['related' => 'user']))
             ->assertJsonStructure([
                 'data' => [
                     'relationships' => [
@@ -54,7 +54,7 @@ class MorphOneFieldTest extends IntegrationTest
 
         $this->assertNotNull($relationships);
 
-        $relationships = $this->getJson(PostWithMorphOneRepository::route($post->id))
+        $relationships = $this->getJson(PostWithMorphOneRepository::route($post))
             ->json('data.relationships');
 
         $this->assertNull($relationships);

--- a/tests/Fields/MorphToManyFieldTest.php
+++ b/tests/Fields/MorphToManyFieldTest.php
@@ -34,7 +34,7 @@ class MorphToManyFieldTest extends IntegrationTest
             );
         });
 
-        $this->getJson(UserWithRolesRepository::route($user->getKey(), [
+        $this->getJson(UserWithRolesRepository::route($user, query: [
             'related' => 'roles',
         ]))->assertJson(
             fn (AssertableJson $json) => $json
@@ -56,7 +56,7 @@ class MorphToManyFieldTest extends IntegrationTest
             );
         });
 
-        $this->getJson(UserWithRolesRepository::route($user->id, ['related' => 'roles,companies']))
+        $this->getJson(UserWithRolesRepository::route($user, query: ['related' => 'roles,companies']))
             ->assertJsonStructure([
                 'data' => [
                     'relationships' => [

--- a/tests/Repositories/RepositorySerializerTest.php
+++ b/tests/Repositories/RepositorySerializerTest.php
@@ -45,14 +45,14 @@ class RepositorySerializerTest extends IntegrationTest
 
         config()->set('restify.repositories.serialize_show_meta', false);
 
-        $this->getJson(PostRepository::route($posts->first()->id))
+        $this->getJson(PostRepository::route($posts->first()))
             ->assertJson(
                 fn (AssertableJson $json) => $json
                 ->missing('data.meta')
                 ->etc()
             );
 
-        $this->getJson(PostRepository::route($posts->first()->id, [
+        $this->getJson(PostRepository::route($posts->first(), query: [
             'withMeta' => true,
         ]))
             ->assertJson(


### PR DESCRIPTION
The new method allows you to send an `Model` object as the `$path` and it allows having an `action` class beside the `query` array