### PR TITLE
[7.x] Do not load singleton DTO in tests

### DIFF
--- a/src/LaravelRestifyServiceProvider.php
+++ b/src/LaravelRestifyServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Binaryk\LaravelRestify;
 
-use Binaryk\LaravelRestify\Bootstrap\RoutesBoot;
 use Binaryk\LaravelRestify\Commands\ActionCommand;
 use Binaryk\LaravelRestify\Commands\BaseRepositoryCommand;
 use Binaryk\LaravelRestify\Commands\DevCommand;
@@ -16,7 +15,6 @@ use Binaryk\LaravelRestify\Commands\SetupCommand;
 use Binaryk\LaravelRestify\Commands\StoreCommand;
 use Binaryk\LaravelRestify\Commands\StubCommand;
 use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\Support\Facades\App;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -49,10 +47,6 @@ class LaravelRestifyServiceProvider extends PackageServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->registerPublishing();
-        }
-
-        if (App::runningInConsole() && ! isset($_SERVER['dont_boot_console_routes'])) {
-            app(RoutesBoot::class)->boot();
         }
     }
 

--- a/src/RestifyApplicationServiceProvider.php
+++ b/src/RestifyApplicationServiceProvider.php
@@ -10,6 +10,7 @@ use Binaryk\LaravelRestify\Http\Controllers\Auth\ResetPasswordController;
 use Binaryk\LaravelRestify\Http\Controllers\Auth\VerifyController;
 use Binaryk\LaravelRestify\Http\Middleware\RestifyInjector;
 use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -120,6 +121,8 @@ class RestifyApplicationServiceProvider extends ServiceProvider
 
     protected function singleton(): void
     {
-        $this->app->singletonIf(RelatedDto::class, fn ($app) => new RelatedDto());
+        if (! App::runningUnitTests()) {
+            $this->app->singletonIf(RelatedDto::class, fn ($app) => new RelatedDto());
+        }
     }
 }

--- a/tests/Console/Commands/RouteListCommandTest.php
+++ b/tests/Console/Commands/RouteListCommandTest.php
@@ -2,12 +2,16 @@
 
 namespace Binaryk\LaravelRestify\Tests\Console\Commands;
 
+use Binaryk\LaravelRestify\Bootstrap\RoutesBoot;
 use Binaryk\LaravelRestify\Tests\IntegrationTest;
 
 class RouteListCommandTest extends IntegrationTest
 {
     public function test_can_list_restify_routes(): void
     {
-//        $this->artisan('route:list')->expectsOutputToContain("api/restify/{repository}");
+        // This is automatically registered in RestifyInjector middleware in a non console env mode.
+        app(RoutesBoot::class)->boot();
+
+        $this->artisan('route:list')->expectsOutputToContain("api/restify/{repository}");
     }
 }

--- a/tests/Console/Commands/RouteListCommandTest.php
+++ b/tests/Console/Commands/RouteListCommandTest.php
@@ -12,6 +12,8 @@ class RouteListCommandTest extends IntegrationTest
         // This is automatically registered in RestifyInjector middleware in a non console env mode.
         app(RoutesBoot::class)->boot();
 
-        $this->artisan('route:list')->expectsOutputToContain("api/restify/{repository}");
+        if (method_exists($command = $this->artisan('route:list'), 'expectsOutputToContain')) {
+            $command->expectsOutputToContain("api/restify/{repository}");
+        }
     }
 }

--- a/tests/Console/Commands/RouteListCommandTest.php
+++ b/tests/Console/Commands/RouteListCommandTest.php
@@ -13,7 +13,7 @@ class RouteListCommandTest extends IntegrationTest
         app(RoutesBoot::class)->boot();
 
         if (method_exists($command = $this->artisan('route:list'), 'expectsOutputToContain')) {
-            $command->expectsOutputToContain("api/restify/{repository}");
+            $command->expectsOutputToContain('api/restify/{repository}');
         }
     }
 }

--- a/tests/Controllers/Index/IndexRelatedFeatureTest.php
+++ b/tests/Controllers/Index/IndexRelatedFeatureTest.php
@@ -29,6 +29,13 @@ class IndexRelatedFeatureTest extends IntegrationTest
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->singletonIf(RelatedDto::class, fn ($app) => new RelatedDto());
+    }
+
     public function test_can_retrieve_nested_relationships(): void
     {
         CompanyRepository::partialMock()

--- a/tests/Unit/RepositoryWithRoutesTest.php
+++ b/tests/Unit/RepositoryWithRoutesTest.php
@@ -11,8 +11,6 @@ class RepositoryWithRoutesTest extends IntegrationTest
 {
     protected function setUp(): void
     {
-        $_SERVER['dont_boot_console_routes'] = true;
-
         parent::setUp();
 
         Restify::repositories([


### PR DESCRIPTION
Considering the RelatedDto is singleton in tests, we cannot call the in the same test different relations, because they were singleton per test (1 test boots the app service providers only once). 

```
postJson(CampaignJobRepository::action(ArchiveCampaignJobRestifyAction::class, $campaignJobId), [
        'archive' => true,
    ])->assertOk();

  postJson(CampaignJobRepository::action(ArchiveCampaignJobRestifyAction::class, $campaignJobId), [
      'archive' => false,
  ])->assertOk();
```

Now it'll do not make it singleton in tests.