### PR TITLE
fix scout when search input is null

### DIFF
--- a/src/Services/Search/RepositorySearchService.php
+++ b/src/Services/Search/RepositorySearchService.php
@@ -187,7 +187,7 @@ class RepositorySearchService
          * @var Collection $keys
          */
         $keys = tap(
-            $repository::newModel()->search($request->input('search')),
+            is_null($request->input('search')) ? $repository::newModel() : $repository::newModel()->search($request->input('search')),
             function ($scoutBuilder) use ($repository, $request) {
                 return $repository::scoutQuery($request, $scoutBuilder);
             }


### PR DESCRIPTION
Fix when using ElasticSearch: Elastic\Elasticsearch\Exception\ClientResponseException: 400 Bad Request: {"error":{"root_cause":[{"type":"parsing_exception","reason":"[query_string] unknown token [VALUE_NULL] after [query]","line":1,"col":35}],"type":"parsing_exception","reason":"[query_string] unknown token [VALUE_NULL] after [query]","line":1,"col":35},"status":400}