### PR TITLE
perf(search): Add alternative search using joins for search subqueries

### DIFF
--- a/config/restify.php
+++ b/config/restify.php
@@ -132,6 +132,19 @@ return [
         | Specify either the search should be case-sensitive or not.
         */
         'case_sensitive' => true,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Search Optimization
+        |--------------------------------------------------------------------------
+        |
+        | When enabled, search queries on related fields will use JOINs instead of
+        | subqueries for better performance. This only affects searchable BelongsTo
+        | relationships, not direct field searches on the main model.
+        |
+        | Set to false to use the legacy subquery approach for backward compatibility.
+        */
+        'use_joins' => env('RESTIFY_SEARCH_USE_JOINS', false),
     ],
 
     'repositories' => [

--- a/docs/eager-loading-optimization.md
+++ b/docs/eager-loading-optimization.md
@@ -1,212 +1,92 @@
 # Search Performance Optimization
 
-Laravel Restify includes an optional search performance optimization that replaces inefficient subqueries with JOIN-based searches for related fields.
+Laravel Restify includes an optional JOIN-based search optimization for better performance when searching through BelongsTo relationship fields.
 
 ## Overview
 
-By default, when searching through BelongsTo relationship fields, Laravel Restify uses subqueries which can be slow for large datasets:
-
+**Default behavior (subqueries):**
 ```sql
--- Default behavior (subqueries)
 SELECT * FROM `invoices` WHERE (
     UPPER(`invoices`.`gross_amount`) LIKE '%CSC%'
     OR (SELECT `vendors`.`code` FROM `vendors` WHERE `vendors`.`id` = `invoices`.`vendor_id` LIMIT 1) LIKE '%csc%'
-    OR (SELECT `vendors`.`name` FROM `vendors` WHERE `vendors`.`id` = `invoices`.`vendor_id` LIMIT 1) LIKE '%csc%'
 )
 ```
 
-With JOIN optimization enabled, these become efficient JOIN-based queries:
-
+**Optimized behavior (JOINs):**
 ```sql
--- Optimized behavior (JOINs)
 SELECT invoices.* FROM `invoices`
 LEFT JOIN `vendors` AS vendors_for_vendor ON invoices.vendor_id = vendors_for_vendor.id
 WHERE (
     UPPER(invoices.gross_amount) LIKE '%CSC%'
     OR UPPER(vendors_for_vendor.code) LIKE '%CSC%'
-    OR UPPER(vendors_for_vendor.name) LIKE '%CSC%'
 )
 ```
 
 ## Configuration
 
-### Enabling JOIN Optimization
-
-Add the following to your `.env` file:
-
+Enable in your `.env` file:
 ```env
 RESTIFY_SEARCH_USE_JOINS=true
 ```
 
-Or configure it directly in `config/restify.php`:
-
+Or in `config/restify.php`:
 ```php
 'search' => [
-    'case_sensitive' => true,
-    'use_joins' => true, // Enable JOIN optimization
+    'use_joins' => true,
 ],
 ```
 
-### Default Behavior
-
-**By default, JOIN optimization is disabled** to maintain backward compatibility. The system will continue using subqueries until explicitly enabled.
+**Default: `false`** (backward compatible)
 
 ## When JOINs Are Used
 
-JOIN optimization is **only applied when**:
+✅ **Applied when:**
+- Config `restify.search.use_joins` is `true`
+- Searching BelongsTo relationship fields marked as searchable
 
-1. ✅ The `restify.search.use_joins` config is set to `true`
-2. ✅ You're searching through a **BelongsTo relationship** field
-3. ✅ The relationship field is marked as **searchable**
+❌ **NOT applied for:**
+- Direct field searches on main model
+- HasMany or other relationship types
+- When config is disabled (default)
 
-JOIN optimization is **NOT applied for**:
+## Usage
 
-- ❌ Direct field searches on the main model
-- ❌ HasMany or other relationship types  
-- ❌ When the config flag is disabled (default)
-
-## Repository Configuration
-
-No changes are needed to your existing repository configuration. The optimization works with your current setup:
+No repository changes needed:
 
 ```php
 class InvoiceRepository extends Repository
 {
     public static function searchables(): array
     {
-        return [
-            'gross_amount', // Direct field - no JOIN needed
-            'number',       // Direct field - no JOIN needed  
-        ];
+        return ['gross_amount', 'number']; // Direct fields - no JOINs
     }
 
     public static function related(): array
     {
         return [
             'vendor' => BelongsTo::make('vendor', VendorRepository::class)->searchable([
-                'vendors.code', // Will use JOIN when optimization enabled
-                'vendors.name', // Will use JOIN when optimization enabled
+                'vendors.code', // Will use JOIN when enabled
+                'vendors.name', // Will use JOIN when enabled
             ]),
         ];
     }
 }
 ```
 
-## Performance Benefits
+## Benefits
 
-### Query Efficiency
-- **Eliminates N+1 subquery problems** - Each related field search no longer creates separate subqueries
-- **Improved query performance** - JOINs are typically much faster than correlated subqueries
-- **Reduced database load** - Single query instead of multiple subqueries per search term
+- **Better performance** - JOINs instead of subqueries
+- **Fewer queries** - Eliminates N+1 subquery problems
+- **Automatic eager loading optimization** - Skips already-joined relationships
 
-### Eager Loading Optimization
-When JOIN optimization is enabled, the system automatically:
-- **Detects already-joined relationships** 
-- **Excludes them from eager loading** to prevent duplicate queries
-- **Maintains data integrity** while improving performance
+## Testing
 
-### Example Performance Impact
-
-**Before Optimization (3 separate subqueries)**:
-```sql
--- Main query + 2 subqueries for each search term
-SELECT * FROM invoices WHERE (
-    gross_amount LIKE '%term%' OR
-    (SELECT code FROM vendors WHERE...) LIKE '%term%' OR  
-    (SELECT name FROM vendors WHERE...) LIKE '%term%'
-)
-```
-
-**After Optimization (1 JOIN query)**:
-```sql
--- Single query with JOIN
-SELECT invoices.* FROM invoices 
-LEFT JOIN vendors AS vendors_for_vendor ON invoices.vendor_id = vendors_for_vendor.id
-WHERE (
-    gross_amount LIKE '%term%' OR
-    vendors_for_vendor.code LIKE '%term%' OR
-    vendors_for_vendor.name LIKE '%term%'
-)
-```
-
-## Backward Compatibility
-
-This feature is **100% backward compatible**:
-
-- **Default behavior unchanged** - Existing applications continue working without any changes
-- **Opt-in optimization** - You must explicitly enable JOIN optimization
-- **No breaking changes** - All existing repository configurations work as before
-- **Gradual adoption** - Enable per environment (dev/staging first, then production)
-
-## Best Practices
-
-### When to Enable
-- ✅ **Large datasets** with frequent relationship searches
-- ✅ **Performance-critical applications** where search speed matters
-- ✅ **Well-tested environments** where you can validate the behavior
-
-### When to Keep Disabled  
-- ❌ **Small datasets** where performance difference is negligible
-- ❌ **Legacy systems** where you want to maintain exact query behavior
-- ❌ **Complex relationship setups** that need specific subquery behavior
-
-### Testing Strategy
-1. **Enable in development/staging first**
-2. **Run your existing test suite** to ensure no regressions
-3. **Monitor query performance** before and after
-4. **Gradually roll out to production**
-
-## Troubleshooting
-
-### Common Issues
-
-**Q: JOINs aren't being used even though the config is enabled**
-A: Verify that:
-- The searchable fields are on BelongsTo relationships (not direct model fields)
-- The relationship is properly configured with `->searchable([...])`
-- Cache has been cleared after config changes
-
-**Q: Getting different search results after enabling JOINs**  
-A: This could indicate:
-- Multi-tenant constraints that were handled differently in subqueries
-- Complex relationship setups that need adjustment
-- Consider disabling the optimization for that specific use case
-
-**Q: Performance didn't improve as expected**
-A: Check that:
-- You have proper database indexes on JOIN columns
-- The dataset is large enough to see meaningful performance differences
-- Other query bottlenecks aren't masking the improvement
-
-### Debugging
-
-Enable query logging to see the generated SQL:
-
+Test in development first:
 ```php
+// Enable query logging to verify behavior
 DB::enableQueryLog();
-// Perform your search
+// Perform search
 $queries = DB::getQueryLog();
-dd($queries);
 ```
 
-Look for `LEFT JOIN` statements in the search queries when optimization is enabled.
-
-## Migration Guide
-
-### Step 1: Test in Development
-```env
-# In .env
-RESTIFY_SEARCH_USE_JOINS=true
-```
-
-### Step 2: Validate Query Behavior
-Run your test suite and verify search results remain consistent.
-
-### Step 3: Performance Testing  
-Measure query performance before and after enabling the optimization.
-
-### Step 4: Production Rollout
-Enable in production after thorough testing in staging environments.
-
-### Step 5: Monitor
-Watch for any performance regressions or unexpected query behavior.
+Look for `LEFT JOIN` statements when optimization is enabled.

--- a/docs/eager-loading-optimization.md
+++ b/docs/eager-loading-optimization.md
@@ -1,0 +1,212 @@
+# Search Performance Optimization
+
+Laravel Restify includes an optional search performance optimization that replaces inefficient subqueries with JOIN-based searches for related fields.
+
+## Overview
+
+By default, when searching through BelongsTo relationship fields, Laravel Restify uses subqueries which can be slow for large datasets:
+
+```sql
+-- Default behavior (subqueries)
+SELECT * FROM `invoices` WHERE (
+    UPPER(`invoices`.`gross_amount`) LIKE '%CSC%'
+    OR (SELECT `vendors`.`code` FROM `vendors` WHERE `vendors`.`id` = `invoices`.`vendor_id` LIMIT 1) LIKE '%csc%'
+    OR (SELECT `vendors`.`name` FROM `vendors` WHERE `vendors`.`id` = `invoices`.`vendor_id` LIMIT 1) LIKE '%csc%'
+)
+```
+
+With JOIN optimization enabled, these become efficient JOIN-based queries:
+
+```sql
+-- Optimized behavior (JOINs)
+SELECT invoices.* FROM `invoices`
+LEFT JOIN `vendors` AS vendors_for_vendor ON invoices.vendor_id = vendors_for_vendor.id
+WHERE (
+    UPPER(invoices.gross_amount) LIKE '%CSC%'
+    OR UPPER(vendors_for_vendor.code) LIKE '%CSC%'
+    OR UPPER(vendors_for_vendor.name) LIKE '%CSC%'
+)
+```
+
+## Configuration
+
+### Enabling JOIN Optimization
+
+Add the following to your `.env` file:
+
+```env
+RESTIFY_SEARCH_USE_JOINS=true
+```
+
+Or configure it directly in `config/restify.php`:
+
+```php
+'search' => [
+    'case_sensitive' => true,
+    'use_joins' => true, // Enable JOIN optimization
+],
+```
+
+### Default Behavior
+
+**By default, JOIN optimization is disabled** to maintain backward compatibility. The system will continue using subqueries until explicitly enabled.
+
+## When JOINs Are Used
+
+JOIN optimization is **only applied when**:
+
+1. ✅ The `restify.search.use_joins` config is set to `true`
+2. ✅ You're searching through a **BelongsTo relationship** field
+3. ✅ The relationship field is marked as **searchable**
+
+JOIN optimization is **NOT applied for**:
+
+- ❌ Direct field searches on the main model
+- ❌ HasMany or other relationship types  
+- ❌ When the config flag is disabled (default)
+
+## Repository Configuration
+
+No changes are needed to your existing repository configuration. The optimization works with your current setup:
+
+```php
+class InvoiceRepository extends Repository
+{
+    public static function searchables(): array
+    {
+        return [
+            'gross_amount', // Direct field - no JOIN needed
+            'number',       // Direct field - no JOIN needed  
+        ];
+    }
+
+    public static function related(): array
+    {
+        return [
+            'vendor' => BelongsTo::make('vendor', VendorRepository::class)->searchable([
+                'vendors.code', // Will use JOIN when optimization enabled
+                'vendors.name', // Will use JOIN when optimization enabled
+            ]),
+        ];
+    }
+}
+```
+
+## Performance Benefits
+
+### Query Efficiency
+- **Eliminates N+1 subquery problems** - Each related field search no longer creates separate subqueries
+- **Improved query performance** - JOINs are typically much faster than correlated subqueries
+- **Reduced database load** - Single query instead of multiple subqueries per search term
+
+### Eager Loading Optimization
+When JOIN optimization is enabled, the system automatically:
+- **Detects already-joined relationships** 
+- **Excludes them from eager loading** to prevent duplicate queries
+- **Maintains data integrity** while improving performance
+
+### Example Performance Impact
+
+**Before Optimization (3 separate subqueries)**:
+```sql
+-- Main query + 2 subqueries for each search term
+SELECT * FROM invoices WHERE (
+    gross_amount LIKE '%term%' OR
+    (SELECT code FROM vendors WHERE...) LIKE '%term%' OR  
+    (SELECT name FROM vendors WHERE...) LIKE '%term%'
+)
+```
+
+**After Optimization (1 JOIN query)**:
+```sql
+-- Single query with JOIN
+SELECT invoices.* FROM invoices 
+LEFT JOIN vendors AS vendors_for_vendor ON invoices.vendor_id = vendors_for_vendor.id
+WHERE (
+    gross_amount LIKE '%term%' OR
+    vendors_for_vendor.code LIKE '%term%' OR
+    vendors_for_vendor.name LIKE '%term%'
+)
+```
+
+## Backward Compatibility
+
+This feature is **100% backward compatible**:
+
+- **Default behavior unchanged** - Existing applications continue working without any changes
+- **Opt-in optimization** - You must explicitly enable JOIN optimization
+- **No breaking changes** - All existing repository configurations work as before
+- **Gradual adoption** - Enable per environment (dev/staging first, then production)
+
+## Best Practices
+
+### When to Enable
+- ✅ **Large datasets** with frequent relationship searches
+- ✅ **Performance-critical applications** where search speed matters
+- ✅ **Well-tested environments** where you can validate the behavior
+
+### When to Keep Disabled  
+- ❌ **Small datasets** where performance difference is negligible
+- ❌ **Legacy systems** where you want to maintain exact query behavior
+- ❌ **Complex relationship setups** that need specific subquery behavior
+
+### Testing Strategy
+1. **Enable in development/staging first**
+2. **Run your existing test suite** to ensure no regressions
+3. **Monitor query performance** before and after
+4. **Gradually roll out to production**
+
+## Troubleshooting
+
+### Common Issues
+
+**Q: JOINs aren't being used even though the config is enabled**
+A: Verify that:
+- The searchable fields are on BelongsTo relationships (not direct model fields)
+- The relationship is properly configured with `->searchable([...])`
+- Cache has been cleared after config changes
+
+**Q: Getting different search results after enabling JOINs**  
+A: This could indicate:
+- Multi-tenant constraints that were handled differently in subqueries
+- Complex relationship setups that need adjustment
+- Consider disabling the optimization for that specific use case
+
+**Q: Performance didn't improve as expected**
+A: Check that:
+- You have proper database indexes on JOIN columns
+- The dataset is large enough to see meaningful performance differences
+- Other query bottlenecks aren't masking the improvement
+
+### Debugging
+
+Enable query logging to see the generated SQL:
+
+```php
+DB::enableQueryLog();
+// Perform your search
+$queries = DB::getQueryLog();
+dd($queries);
+```
+
+Look for `LEFT JOIN` statements in the search queries when optimization is enabled.
+
+## Migration Guide
+
+### Step 1: Test in Development
+```env
+# In .env
+RESTIFY_SEARCH_USE_JOINS=true
+```
+
+### Step 2: Validate Query Behavior
+Run your test suite and verify search results remain consistent.
+
+### Step 3: Performance Testing  
+Measure query performance before and after enabling the optimization.
+
+### Step 4: Production Rollout
+Enable in production after thorough testing in staging environments.
+
+### Step 5: Monitor
+Watch for any performance regressions or unexpected query behavior.

--- a/src/Filters/SearchableFilter.php
+++ b/src/Filters/SearchableFilter.php
@@ -62,36 +62,36 @@ class SearchableFilter extends Filter
     {
         $relatedModel = $this->belongsToField->getRelatedModel($this->repository);
         $relatedTable = $relatedModel->getTable();
-        
+
         // Corrected: getRelatedKey is foreign key on parent, getQualifiedKey is primary key on related
         $foreignKey = $this->belongsToField->getRelatedKey($this->repository); // e.g., invoices.vendor_id
         $relatedKey = $this->belongsToField->getQualifiedKey($this->repository); // e.g., vendors.id
-        
+
         // Use a consistent alias based on the relationship name to reuse joins
         $relationshipName = $this->belongsToField->getAttribute();
         $joinAlias = "{$relatedTable}_for_{$relationshipName}";
-        
+
         // Check if this exact join already exists
         $existingJoins = collect($query->getQuery()->joins ?? []);
         $joinExists = $existingJoins->contains(function ($join) use ($joinAlias, $relatedTable) {
-            return $join->table === "{$relatedTable} as {$joinAlias}" || 
+            return $join->table === "{$relatedTable} as {$joinAlias}" ||
                    str_contains($join->table, $joinAlias);
         });
-        
-        if (!$joinExists) {
+
+        if (! $joinExists) {
             $query->leftJoin("{$relatedTable} as {$joinAlias}", function ($join) use ($foreignKey, $joinAlias, $relatedModel) {
                 // Join parent.foreign_key = related_alias.id
                 $join->on($foreignKey, '=', "{$joinAlias}.{$relatedModel->getKeyName()}");
             });
         }
-        
+
         // Apply search conditions for each searchable attribute
         collect($this->belongsToField->getSearchables())->each(function (string $attribute) use ($query, $likeOperator, $value, $joinAlias) {
             // Extract column name from qualified attribute (e.g., vendors.name -> name)
             $columnName = str_contains($attribute, '.') ? explode('.', $attribute)[1] : $attribute;
             $qualifiedAttribute = "{$joinAlias}.{$columnName}";
-            
-            if (!config('restify.search.case_sensitive')) {
+
+            if (! config('restify.search.case_sensitive')) {
                 $upper = strtoupper($value);
                 $query->orWhereRaw("UPPER({$qualifiedAttribute}) LIKE ?", ['%'.$upper.'%']);
             } else {
@@ -106,7 +106,7 @@ class SearchableFilter extends Filter
         collect($this->belongsToField->getSearchables())->each(function (string $attribute) use ($query, $likeOperator, $value) {
             // Extract column name from qualified attribute (e.g., vendors.name -> name)
             $columnName = str_contains($attribute, '.') ? explode('.', $attribute)[1] : $attribute;
-            
+
             $query->orWhere(
                 $this->belongsToField->getRelatedModel($this->repository)::select($columnName)
                     ->whereColumn(
@@ -119,5 +119,4 @@ class SearchableFilter extends Filter
             );
         });
     }
-
 }

--- a/src/Filters/SearchableFilter.php
+++ b/src/Filters/SearchableFilter.php
@@ -62,10 +62,10 @@ class SearchableFilter extends Filter
     {
         $relatedModel = $this->belongsToField->getRelatedModel($this->repository);
         $relatedTable = $relatedModel->getTable();
-        $parentTable = $this->repository->model()->getTable();
         
-        $localKey = $this->belongsToField->getQualifiedKey($this->repository);
-        $foreignKeyName = $relatedModel->getKeyName();
+        // Corrected: getRelatedKey is foreign key on parent, getQualifiedKey is primary key on related
+        $foreignKey = $this->belongsToField->getRelatedKey($this->repository); // e.g., invoices.vendor_id
+        $relatedKey = $this->belongsToField->getQualifiedKey($this->repository); // e.g., vendors.id
         
         // Use a consistent alias based on the relationship name to reuse joins
         $relationshipName = $this->belongsToField->getAttribute();
@@ -79,14 +79,17 @@ class SearchableFilter extends Filter
         });
         
         if (!$joinExists) {
-            $query->leftJoin("{$relatedTable} as {$joinAlias}", function ($join) use ($localKey, $joinAlias, $foreignKeyName) {
-                $join->on($localKey, '=', "{$joinAlias}.{$foreignKeyName}");
+            $query->leftJoin("{$relatedTable} as {$joinAlias}", function ($join) use ($foreignKey, $joinAlias, $relatedModel) {
+                // Join parent.foreign_key = related_alias.id
+                $join->on($foreignKey, '=', "{$joinAlias}.{$relatedModel->getKeyName()}");
             });
         }
         
         // Apply search conditions for each searchable attribute
         collect($this->belongsToField->getSearchables())->each(function (string $attribute) use ($query, $likeOperator, $value, $joinAlias) {
-            $qualifiedAttribute = "{$joinAlias}.{$attribute}";
+            // Extract column name from qualified attribute (e.g., vendors.name -> name)
+            $columnName = str_contains($attribute, '.') ? explode('.', $attribute)[1] : $attribute;
+            $qualifiedAttribute = "{$joinAlias}.{$columnName}";
             
             if (!config('restify.search.case_sensitive')) {
                 $upper = strtoupper($value);
@@ -101,11 +104,14 @@ class SearchableFilter extends Filter
     {
         // Original implementation using subqueries for backward compatibility
         collect($this->belongsToField->getSearchables())->each(function (string $attribute) use ($query, $likeOperator, $value) {
+            // Extract column name from qualified attribute (e.g., vendors.name -> name)
+            $columnName = str_contains($attribute, '.') ? explode('.', $attribute)[1] : $attribute;
+            
             $query->orWhere(
-                $this->belongsToField->getRelatedModel($this->repository)::select($attribute)
+                $this->belongsToField->getRelatedModel($this->repository)::select($columnName)
                     ->whereColumn(
-                        $this->belongsToField->getQualifiedKey($this->repository),
-                        $this->belongsToField->getRelatedKey($this->repository)
+                        $this->belongsToField->getQualifiedKey($this->repository), // related.id
+                        $this->belongsToField->getRelatedKey($this->repository)    // parent.foreign_key
                     )
                     ->take(1),
                 $likeOperator,

--- a/src/Filters/SearchableFilter.php
+++ b/src/Filters/SearchableFilter.php
@@ -24,23 +24,17 @@ class SearchableFilter extends Filter
                 return $query;
             }
 
-            // This approach could be rewritten using join.
-            collect($this->belongsToField->getSearchables())->each(function (string $attribute) use ($query, $likeOperator, $value) {
-                $query->orWhere(
-                    $this->belongsToField->getRelatedModel($this->repository)::select($attribute)
-                        ->whereColumn(
-                            $this->belongsToField->getQualifiedKey($this->repository),
-                            $this->belongsToField->getRelatedKey($this->repository)
-                        )
-                        ->take(1),
-                    $likeOperator,
-                    "%{$value}%"
-                );
-            });
+            // Use JOIN optimization only if enabled in config and we have a BelongsTo relationship
+            if (config('restify.search.use_joins', false)) {
+                $this->applyJoinSearchConditions($query, $likeOperator, $value);
+            } else {
+                $this->applySubquerySearchConditions($query, $likeOperator, $value);
+            }
 
             return $query;
         }
 
+        // For direct field searches (non-relationship), always use the simple approach
         if (! config('restify.search.case_sensitive')) {
             $upper = strtoupper($value);
 
@@ -63,4 +57,61 @@ class SearchableFilter extends Filter
 
         return $this;
     }
+
+    protected function applyJoinSearchConditions($query, $likeOperator, $value)
+    {
+        $relatedModel = $this->belongsToField->getRelatedModel($this->repository);
+        $relatedTable = $relatedModel->getTable();
+        $parentTable = $this->repository->model()->getTable();
+        
+        $localKey = $this->belongsToField->getQualifiedKey($this->repository);
+        $foreignKeyName = $relatedModel->getKeyName();
+        
+        // Use a consistent alias based on the relationship name to reuse joins
+        $relationshipName = $this->belongsToField->getAttribute();
+        $joinAlias = "{$relatedTable}_for_{$relationshipName}";
+        
+        // Check if this exact join already exists
+        $existingJoins = collect($query->getQuery()->joins ?? []);
+        $joinExists = $existingJoins->contains(function ($join) use ($joinAlias, $relatedTable) {
+            return $join->table === "{$relatedTable} as {$joinAlias}" || 
+                   str_contains($join->table, $joinAlias);
+        });
+        
+        if (!$joinExists) {
+            $query->leftJoin("{$relatedTable} as {$joinAlias}", function ($join) use ($localKey, $joinAlias, $foreignKeyName) {
+                $join->on($localKey, '=', "{$joinAlias}.{$foreignKeyName}");
+            });
+        }
+        
+        // Apply search conditions for each searchable attribute
+        collect($this->belongsToField->getSearchables())->each(function (string $attribute) use ($query, $likeOperator, $value, $joinAlias) {
+            $qualifiedAttribute = "{$joinAlias}.{$attribute}";
+            
+            if (!config('restify.search.case_sensitive')) {
+                $upper = strtoupper($value);
+                $query->orWhereRaw("UPPER({$qualifiedAttribute}) LIKE ?", ['%'.$upper.'%']);
+            } else {
+                $query->orWhere($qualifiedAttribute, $likeOperator, "%{$value}%");
+            }
+        });
+    }
+
+    protected function applySubquerySearchConditions($query, $likeOperator, $value)
+    {
+        // Original implementation using subqueries for backward compatibility
+        collect($this->belongsToField->getSearchables())->each(function (string $attribute) use ($query, $likeOperator, $value) {
+            $query->orWhere(
+                $this->belongsToField->getRelatedModel($this->repository)::select($attribute)
+                    ->whereColumn(
+                        $this->belongsToField->getQualifiedKey($this->repository),
+                        $this->belongsToField->getRelatedKey($this->repository)
+                    )
+                    ->take(1),
+                $likeOperator,
+                "%{$value}%"
+            );
+        });
+    }
+
 }

--- a/src/Filters/SearchableFilter.php
+++ b/src/Filters/SearchableFilter.php
@@ -63,32 +63,32 @@ class SearchableFilter extends Filter
         $relatedModel = $this->belongsToField->getRelatedModel($this->repository);
         $relatedTable = $relatedModel->getTable();
         $parentTable = $this->repository->model()->getTable();
-        
+
         $localKey = $this->belongsToField->getQualifiedKey($this->repository);
         $foreignKeyName = $relatedModel->getKeyName();
-        
+
         // Use a consistent alias based on the relationship name to reuse joins
         $relationshipName = $this->belongsToField->getAttribute();
         $joinAlias = "{$relatedTable}_for_{$relationshipName}";
-        
+
         // Check if this exact join already exists
         $existingJoins = collect($query->getQuery()->joins ?? []);
         $joinExists = $existingJoins->contains(function ($join) use ($joinAlias, $relatedTable) {
-            return $join->table === "{$relatedTable} as {$joinAlias}" || 
+            return $join->table === "{$relatedTable} as {$joinAlias}" ||
                    str_contains($join->table, $joinAlias);
         });
-        
-        if (!$joinExists) {
+
+        if (! $joinExists) {
             $query->leftJoin("{$relatedTable} as {$joinAlias}", function ($join) use ($localKey, $joinAlias, $foreignKeyName) {
                 $join->on($localKey, '=', "{$joinAlias}.{$foreignKeyName}");
             });
         }
-        
+
         // Apply search conditions for each searchable attribute
         collect($this->belongsToField->getSearchables())->each(function (string $attribute) use ($query, $likeOperator, $value, $joinAlias) {
             $qualifiedAttribute = "{$joinAlias}.{$attribute}";
-            
-            if (!config('restify.search.case_sensitive')) {
+
+            if (! config('restify.search.case_sensitive')) {
                 $upper = strtoupper($value);
                 $query->orWhereRaw("UPPER({$qualifiedAttribute}) LIKE ?", ['%'.$upper.'%']);
             } else {
@@ -113,5 +113,4 @@ class SearchableFilter extends Filter
             );
         });
     }
-
 }

--- a/src/Services/Search/RepositorySearchService.php
+++ b/src/Services/Search/RepositorySearchService.php
@@ -116,13 +116,13 @@ class RepositorySearchService
         })->all();
 
         $eagerRelations = array_merge($filtered, ($this->repository)::withs());
-        
+
         // Only exclude joined relationships if JOIN optimization is enabled
         if (config('restify.search.use_joins', false)) {
             $joinedRelations = $this->getJoinedRelationships($query);
             $eagerRelations = array_diff($eagerRelations, $joinedRelations);
         }
-        
+
         return $query->with($eagerRelations);
     }
 
@@ -254,7 +254,7 @@ class RepositorySearchService
     {
         $joinedRelations = [];
         $joins = collect($query->getQuery()->joins ?? []);
-        
+
         // Extract relationship names from join aliases
         $joins->each(function ($join) use (&$joinedRelations) {
             if (str_contains($join->table, '_for_')) {
@@ -262,7 +262,7 @@ class RepositorySearchService
                 $joinedRelations[] = $relationName;
             }
         });
-        
+
         return $joinedRelations;
     }
 

--- a/src/Services/Search/RepositorySearchService.php
+++ b/src/Services/Search/RepositorySearchService.php
@@ -115,9 +115,15 @@ class RepositorySearchService
             }
         })->all();
 
-        return $query->with(
-            array_merge($filtered, ($this->repository)::withs())
-        );
+        $eagerRelations = array_merge($filtered, ($this->repository)::withs());
+        
+        // Only exclude joined relationships if JOIN optimization is enabled
+        if (config('restify.search.use_joins', false)) {
+            $joinedRelations = $this->getJoinedRelationships($query);
+            $eagerRelations = array_diff($eagerRelations, $joinedRelations);
+        }
+        
+        return $query->with($eagerRelations);
     }
 
     public function prepareSearchFields(RestifyRequest $request, $query)
@@ -142,6 +148,7 @@ class RepositorySearchService
                 $query->orWhere($query->getModel()->getQualifiedKeyName(), $search);
             }
 
+            // Apply local field searches
             foreach ($this->repository::searchables() as $key => $column) {
                 $filter = $column instanceof Filter
                     ? $column
@@ -156,14 +163,15 @@ class RepositorySearchService
                     );
 
                 $filter->filter($request, $query, $search);
-
-                $this->repository::collectRelated()
-                    ->onlySearchable($request)
-                    ->map(function (BelongsTo $field) {
-                        return SearchableFilter::make()->setRepository($this->repository)->usingBelongsTo($field);
-                    })
-                    ->each(fn (SearchableFilter $filter) => $filter->filter($request, $query, $search));
             }
+
+            // Apply related field searches (moved outside the loop to avoid duplicate joins)
+            $this->repository::collectRelated()
+                ->onlySearchable($request)
+                ->map(function (BelongsTo $field) {
+                    return SearchableFilter::make()->setRepository($this->repository)->usingBelongsTo($field);
+                })
+                ->each(fn (SearchableFilter $filter) => $filter->filter($request, $query, $search));
         });
 
         return $query;
@@ -240,6 +248,22 @@ class RepositorySearchService
         }
 
         return $query;
+    }
+
+    protected function getJoinedRelationships($query): array
+    {
+        $joinedRelations = [];
+        $joins = collect($query->getQuery()->joins ?? []);
+        
+        // Extract relationship names from join aliases
+        $joins->each(function ($join) use (&$joinedRelations) {
+            if (str_contains($join->table, '_for_')) {
+                $relationName = str($join->table)->after('_for_')->toString();
+                $joinedRelations[] = $relationName;
+            }
+        });
+        
+        return $joinedRelations;
     }
 
     public static function make(): static

--- a/tests/Controllers/Index/EagerLoadingOptimizationTest.php
+++ b/tests/Controllers/Index/EagerLoadingOptimizationTest.php
@@ -1,0 +1,469 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Controllers\Index;
+
+use Binaryk\LaravelRestify\Fields\BelongsTo;
+use Binaryk\LaravelRestify\Fields\HasMany;
+use Binaryk\LaravelRestify\Tests\Database\Factories\CompanyFactory;
+use Binaryk\LaravelRestify\Tests\Database\Factories\PostFactory;
+use Binaryk\LaravelRestify\Tests\Database\Factories\UserFactory;
+use Binaryk\LaravelRestify\Tests\Fixtures\Company\Company;
+use Binaryk\LaravelRestify\Tests\Fixtures\Company\CompanyRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
+use Binaryk\LaravelRestify\Tests\IntegrationTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+
+class EagerLoadingOptimizationTest extends IntegrationTestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        DB::enableQueryLog();
+    }
+
+    protected function tearDown(): void
+    {
+        DB::disableQueryLog();
+        
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_prevents_n_plus_one_queries_with_single_related_field(): void
+    {
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class),
+        ];
+
+        Company::factory()
+            ->has(User::factory()->count(50))
+            ->create(['name' => 'Test Company']);
+
+        DB::flushQueryLog();
+
+        $this->getJson(UserRepository::route(query: [
+            'related' => 'company',
+            'perPage' => 50,
+        ]))->assertOk();
+
+        $queries = DB::getQueryLog();
+        
+        // Should have exactly 2 queries:
+        // 1. Select users
+        // 2. Select companies (eager loaded)
+        $this->assertCount(2, $queries, 'Expected 2 queries but got ' . count($queries));
+        
+        // Verify the second query is an IN query for companies
+        $this->assertStringContainsString('where "companies"."id" in', $queries[1]['query']);
+    }
+
+    #[Test]
+    public function it_prevents_n_plus_one_queries_with_multiple_related_fields(): void
+    {
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class),
+            'posts' => HasMany::make('posts', PostRepository::class),
+        ];
+
+        Company::factory()
+            ->has(
+                User::factory()
+                    ->has(Post::factory()->count(3))
+                    ->count(20)
+            )
+            ->create();
+
+        DB::flushQueryLog();
+
+        $this->getJson(UserRepository::route(query: [
+            'related' => 'company,posts',
+            'perPage' => 20,
+        ]))->assertOk();
+
+        $queries = DB::getQueryLog();
+        
+        // Should have exactly 3 queries:
+        // 1. Select users
+        // 2. Select companies (eager loaded)
+        // 3. Select posts (eager loaded)
+        $this->assertCount(3, $queries, 'Expected 3 queries but got ' . count($queries));
+    }
+
+
+    #[Test]
+    public function it_handles_nested_relationships_without_n_plus_one(): void
+    {
+        PostRepository::$related = [
+            'user' => BelongsTo::make('user', UserRepository::class),
+        ];
+        
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class),
+        ];
+
+        Company::factory()
+            ->has(
+                User::factory()
+                    ->has(Post::factory()->count(2))
+                    ->count(5)
+            )
+            ->create();
+
+        DB::flushQueryLog();
+
+        $this->getJson(PostRepository::route(query: [
+            'related' => 'user.company',
+            'perPage' => 10,
+        ]))->assertOk();
+
+        $queries = DB::getQueryLog();
+        
+        // Should have exactly 3 queries:
+        // 1. Select posts
+        // 2. Select users (eager loaded)
+        // 3. Select companies (eager loaded)
+        $this->assertCount(3, $queries, 'Expected 3 queries but got ' . count($queries));
+    }
+
+    #[Test]
+    public function it_uses_eager_loaded_data_when_relation_already_loaded(): void
+    {
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class),
+        ];
+
+        $company = Company::factory()->create(['name' => 'Preloaded Company']);
+        $user = User::factory()->for($company)->create();
+        
+        // Manually load the relation
+        $user->load('company');
+        
+        // Mock the repository to use our preloaded user
+        UserRepository::partialMock()
+            ->shouldReceive('indexQuery')
+            ->andReturn(User::where('id', $user->id));
+
+        DB::flushQueryLog();
+
+        $response = $this->getJson(UserRepository::route(query: [
+            'related' => 'company',
+        ]))->assertOk();
+
+        $queries = DB::getQueryLog();
+        
+        // Should have only 1 query (to get the user)
+        // The company should not be queried again since it's already loaded
+        $this->assertCount(1, $queries, 'Expected 1 query but got ' . count($queries));
+        
+        // Verify the response still includes the company data
+        $response->assertJson([
+            'data' => [
+                [
+                    'relationships' => [
+                        'company' => [
+                            'attributes' => [
+                                'name' => 'Preloaded Company',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function it_handles_empty_relationships_without_errors(): void
+    {
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class),
+            'posts' => HasMany::make('posts', PostRepository::class),
+        ];
+
+        // Create users without companies or posts
+        User::factory()->count(5)->create(['company_id' => null]);
+
+        DB::flushQueryLog();
+
+        $response = $this->getJson(UserRepository::route(query: [
+            'related' => 'company,posts',
+            'perPage' => 5,
+        ]))->assertOk();
+
+        $queries = DB::getQueryLog();
+        
+        // Should still attempt to eager load (1 query for users, potentially queries for relations)
+        $this->assertGreaterThanOrEqual(1, count($queries));
+        
+        // Verify response handles null relationships correctly
+        $response->assertJson([
+            'data' => [
+                [
+                    'relationships' => [
+                        'company' => null,
+                        'posts' => [],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function it_handles_pagination_with_eager_loading(): void
+    {
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class),
+        ];
+
+        Company::factory()
+            ->has(User::factory()->count(100))
+            ->create();
+
+        // Test first page
+        DB::flushQueryLog();
+        
+        $this->getJson(UserRepository::route(query: [
+            'related' => 'company',
+            'perPage' => 20,
+            'page' => 1,
+        ]))->assertOk();
+
+        $firstPageQueries = count(DB::getQueryLog());
+        
+        // Test second page
+        DB::flushQueryLog();
+        
+        $this->getJson(UserRepository::route(query: [
+            'related' => 'company',
+            'perPage' => 20,
+            'page' => 2,
+        ]))->assertOk();
+
+        $secondPageQueries = count(DB::getQueryLog());
+        
+        // Both pages should have the same number of queries (no N+1)
+        $this->assertEquals($firstPageQueries, $secondPageQueries);
+        $this->assertEquals(2, $secondPageQueries); // Users + Companies
+    }
+
+    #[Test]
+    public function it_uses_joins_when_optimization_enabled(): void
+    {
+        // Enable JOIN optimization
+        config(['restify.search.use_joins' => true]);
+        
+        UserRepository::$search = ['name'];
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
+                'companies.name',
+            ]),
+        ];
+
+        $company = Company::factory()->create(['name' => 'TechCorp']);
+        User::factory()->for($company)->create(['name' => 'John Doe']);
+
+        DB::flushQueryLog();
+
+        $this->getJson(UserRepository::route(query: ['search' => 'TechCorp']))
+            ->assertOk();
+
+        $queries = DB::getQueryLog();
+        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'techcorp'));
+
+        $this->assertNotNull($searchQuery, 'Search query should be executed');
+        
+        // Verify JOIN is used instead of subquery
+        $sql = strtolower($searchQuery['query']);
+        $this->assertStringContainsString('left join', $sql, 'Query should use LEFT JOIN when optimization is enabled');
+        $this->assertStringContainsString('companies_for_company', $sql, 'Query should use consistent alias');
+        
+        // Verify no subquery is used
+        $this->assertStringNotContainsString('select * from "companies" where', $sql, 'Query should not contain subquery when JOINs are enabled');
+        
+        // Reset config
+        config(['restify.search.use_joins' => false]);
+    }
+
+    #[Test]
+    public function it_uses_subqueries_when_optimization_disabled(): void
+    {
+        // Ensure JOIN optimization is disabled (default behavior)
+        config(['restify.search.use_joins' => false]);
+        
+        UserRepository::$search = ['name'];
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
+                'companies.name',
+            ]),
+        ];
+
+        $company = Company::factory()->create(['name' => 'LegacyCorp']);
+        User::factory()->for($company)->create(['name' => 'Jane Doe']);
+
+        DB::flushQueryLog();
+
+        $this->getJson(UserRepository::route(query: ['search' => 'LegacyCorp']))
+            ->assertOk();
+
+        $queries = DB::getQueryLog();
+        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'legacycorp'));
+
+        $this->assertNotNull($searchQuery, 'Search query should be executed');
+        
+        // Verify subquery is used (legacy behavior)
+        $sql = strtolower($searchQuery['query']);
+        $this->assertStringNotContainsString('left join', $sql, 'Query should not use LEFT JOIN when optimization is disabled');
+        $this->assertStringContainsString('select "companies"."name" from "companies"', $sql, 'Query should contain subquery when JOINs are disabled');
+    }
+
+    #[Test]
+    public function it_does_not_affect_direct_field_searches(): void
+    {
+        // Enable JOIN optimization
+        config(['restify.search.use_joins' => true]);
+        
+        UserRepository::$search = ['name', 'email']; // Direct fields only, no relationships
+        UserRepository::$related = [];
+
+        User::factory()->create(['name' => 'DirectSearch', 'email' => 'direct@test.com']);
+
+        DB::flushQueryLog();
+
+        $this->getJson(UserRepository::route(query: ['search' => 'DirectSearch']))
+            ->assertOk();
+
+        $queries = DB::getQueryLog();
+        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'directsearch'));
+
+        $this->assertNotNull($searchQuery, 'Search query should be executed');
+        
+        // Verify no JOINs are used for direct field searches
+        $sql = strtolower($searchQuery['query']);
+        $this->assertStringNotContainsString('left join', $sql, 'Direct field searches should not use JOINs');
+        $this->assertStringNotContainsString('select', $sql . ' from', 'Direct field searches should not contain subqueries');
+        
+        // Reset config
+        config(['restify.search.use_joins' => false]);
+    }
+
+    #[Test]
+    public function it_avoids_eager_loading_joined_relationships_when_optimization_enabled(): void
+    {
+        // Enable JOIN optimization
+        config(['restify.search.use_joins' => true]);
+        
+        UserRepository::$search = ['name'];
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
+                'companies.name',
+            ]),
+        ];
+        UserRepository::$with = ['company']; // This should be optimized away when JOINs are enabled
+
+        $company = Company::factory()->create(['name' => 'JoinedCorp']);
+        User::factory()->for($company)->create(['name' => 'Jane Doe']);
+
+        DB::flushQueryLog();
+
+        $this->getJson(UserRepository::route(query: [
+            'search' => 'JoinedCorp',
+            'related' => 'company'
+        ]))->assertOk();
+
+        $queries = DB::getQueryLog();
+        
+        // Should not have separate eager loading query for company since it's already joined
+        $companyEagerQueries = collect($queries)->filter(function($query) {
+            return str_contains($query['query'], 'select * from "companies"') && 
+                   str_contains($query['query'], 'where "companies"."id" in');
+        });
+
+        $this->assertCount(0, $companyEagerQueries, 'Should not eager load joined relationships when JOIN optimization is enabled');
+        
+        // Reset config
+        config(['restify.search.use_joins' => false]);
+    }
+
+    #[Test]
+    public function it_still_eager_loads_when_optimization_disabled(): void
+    {
+        // Ensure JOIN optimization is disabled (default behavior)
+        config(['restify.search.use_joins' => false]);
+        
+        UserRepository::$search = ['name'];
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
+                'companies.name',
+            ]),
+        ];
+        UserRepository::$with = ['company']; // This should still eager load when JOINs are disabled
+
+        $company = Company::factory()->create(['name' => 'EagerCorp']);
+        User::factory()->for($company)->create(['name' => 'Jane Doe']);
+
+        DB::flushQueryLog();
+
+        $this->getJson(UserRepository::route(query: [
+            'search' => 'EagerCorp',
+            'related' => 'company'
+        ]))->assertOk();
+
+        $queries = DB::getQueryLog();
+        
+        // Should have separate eager loading query for company since JOINs are disabled
+        $companyEagerQueries = collect($queries)->filter(function($query) {
+            return str_contains($query['query'], 'select * from "companies"') && 
+                   str_contains($query['query'], 'where "companies"."id" in');
+        });
+
+        $this->assertGreaterThan(0, $companyEagerQueries->count(), 'Should eager load relationships when JOIN optimization is disabled');
+    }
+
+    #[Test]
+    public function it_handles_multiple_searchable_relations_with_unique_joins_when_enabled(): void
+    {
+        // Enable JOIN optimization
+        config(['restify.search.use_joins' => true]);
+        
+        PostRepository::$search = ['title'];
+        PostRepository::$related = [
+            'user' => BelongsTo::make('user', UserRepository::class)->searchable([
+                'users.name',
+                'users.email',
+            ]),
+        ];
+
+        $user = User::factory()->create(['name' => 'SearchUser', 'email' => 'search@test.com']);
+        Post::factory()->for($user)->create(['title' => 'Test Post']);
+
+        DB::flushQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['search' => 'SearchUser']))
+            ->assertOk();
+
+        $queries = DB::getQueryLog();
+        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'searchuser'));
+
+        $this->assertNotNull($searchQuery);
+        
+        $sql = strtolower($searchQuery['query']);
+        
+        // Should have single JOIN for the user relationship when optimization is enabled
+        $joinCount = substr_count($sql, 'left join "users"');
+        $this->assertEquals(1, $joinCount, 'Should have exactly one JOIN for user relationship when optimization is enabled');
+        
+        // Should search on multiple fields from the joined table
+        $this->assertStringContainsString('"users_for_user"."name"', $sql);
+        $this->assertStringContainsString('"users_for_user"."email"', $sql);
+        
+        // Reset config
+        config(['restify.search.use_joins' => false]);
+    }
+}

--- a/tests/Controllers/Index/EagerLoadingOptimizationTest.php
+++ b/tests/Controllers/Index/EagerLoadingOptimizationTest.php
@@ -4,9 +4,6 @@ namespace Binaryk\LaravelRestify\Tests\Controllers\Index;
 
 use Binaryk\LaravelRestify\Fields\BelongsTo;
 use Binaryk\LaravelRestify\Fields\HasMany;
-use Binaryk\LaravelRestify\Tests\Database\Factories\CompanyFactory;
-use Binaryk\LaravelRestify\Tests\Database\Factories\PostFactory;
-use Binaryk\LaravelRestify\Tests\Database\Factories\UserFactory;
 use Binaryk\LaravelRestify\Tests\Fixtures\Company\Company;
 use Binaryk\LaravelRestify\Tests\Fixtures\Company\CompanyRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
@@ -25,7 +22,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         // Reset repository configurations before each test
         UserRepository::$search = [];
         UserRepository::$related = [];
@@ -33,17 +30,17 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         PostRepository::$search = [];
         PostRepository::$related = [];
         PostRepository::$with = [];
-        
+
         // Reset config to default
         config(['restify.search.use_joins' => false]);
-        
+
         DB::enableQueryLog();
     }
 
     protected function tearDown(): void
     {
         DB::disableQueryLog();
-        
+
         // Clean up repository configurations after each test
         UserRepository::$search = [];
         UserRepository::$related = [];
@@ -51,10 +48,10 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         PostRepository::$search = [];
         PostRepository::$related = [];
         PostRepository::$with = [];
-        
+
         // Reset config to default
         config(['restify.search.use_joins' => false]);
-        
+
         parent::tearDown();
     }
 
@@ -77,12 +74,12 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should have exactly 2 queries:
         // 1. Select users
         // 2. Select companies (eager loaded)
-        $this->assertCount(2, $queries, 'Expected 2 queries but got ' . count($queries));
-        
+        $this->assertCount(2, $queries, 'Expected 2 queries but got '.count($queries));
+
         // Verify the second query is an IN query for companies
         $this->assertStringContainsString('where "companies"."id" in', $queries[1]['query']);
     }
@@ -111,14 +108,13 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should have exactly 3 queries:
         // 1. Select users
         // 2. Select companies (eager loaded)
         // 3. Select posts (eager loaded)
-        $this->assertCount(3, $queries, 'Expected 3 queries but got ' . count($queries));
+        $this->assertCount(3, $queries, 'Expected 3 queries but got '.count($queries));
     }
-
 
     #[Test]
     public function it_handles_nested_relationships_without_n_plus_one(): void
@@ -126,7 +122,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         PostRepository::$related = [
             'user' => BelongsTo::make('user', UserRepository::class),
         ];
-        
+
         UserRepository::$related = [
             'company' => BelongsTo::make('company', CompanyRepository::class),
         ];
@@ -147,12 +143,12 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should have exactly 3 queries:
         // 1. Select posts
         // 2. Select users (eager loaded)
         // 3. Select companies (eager loaded)
-        $this->assertCount(3, $queries, 'Expected 3 queries but got ' . count($queries));
+        $this->assertCount(3, $queries, 'Expected 3 queries but got '.count($queries));
     }
 
     #[Test]
@@ -164,10 +160,10 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
 
         $company = Company::factory()->create(['name' => 'Preloaded Company']);
         $user = User::factory()->for($company)->create();
-        
+
         // Manually load the relation
         $user->load('company');
-        
+
         // Mock the repository to use our preloaded user
         UserRepository::partialMock()
             ->shouldReceive('indexQuery')
@@ -180,11 +176,11 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should have only 1 query (to get the user)
         // The company should not be queried again since it's already loaded
-        $this->assertCount(1, $queries, 'Expected 1 query but got ' . count($queries));
-        
+        $this->assertCount(1, $queries, 'Expected 1 query but got '.count($queries));
+
         // Verify the response still includes the company data
         $response->assertJson([
             'data' => [
@@ -220,10 +216,10 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should still attempt to eager load (1 query for users, potentially queries for relations)
         $this->assertGreaterThanOrEqual(1, count($queries));
-        
+
         // Verify response handles null relationships correctly
         $response->assertJson([
             'data' => [
@@ -250,7 +246,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
 
         // Test first page
         DB::flushQueryLog();
-        
+
         $this->getJson(UserRepository::route(query: [
             'related' => 'company',
             'perPage' => 20,
@@ -258,10 +254,10 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $firstPageQueries = count(DB::getQueryLog());
-        
+
         // Test second page
         DB::flushQueryLog();
-        
+
         $this->getJson(UserRepository::route(query: [
             'related' => 'company',
             'perPage' => 20,
@@ -269,7 +265,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $secondPageQueries = count(DB::getQueryLog());
-        
+
         // Both pages should have the same number of queries (no N+1)
         $this->assertEquals($firstPageQueries, $secondPageQueries);
         $this->assertEquals(2, $secondPageQueries); // Users + Companies
@@ -280,7 +276,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
-        
+
         UserRepository::$search = ['name'];
         UserRepository::$related = [
             'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
@@ -297,22 +293,22 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
             ->assertOk();
 
         $queries = DB::getQueryLog();
-        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'techcorp'));
+        $searchQuery = collect($queries)->first(fn ($query) => str_contains(strtolower($query['query']), 'techcorp'));
 
         $this->assertNotNull($searchQuery, 'Search query should be executed');
-        
+
         // Debug: dump the actual query to see its structure
-        if (!$searchQuery) {
-            $this->fail('No search query found. Queries: ' . json_encode($queries));
+        if (! $searchQuery) {
+            $this->fail('No search query found. Queries: '.json_encode($queries));
         }
-        
+
         // Verify JOIN is used instead of subquery
         $sql = strtolower($searchQuery['query']);
-        $this->assertStringContainsString('left join', $sql, 'Query should use LEFT JOIN when optimization is enabled. SQL: ' . $sql);
-        $this->assertStringContainsString('companies_for_company', $sql, 'Query should use consistent alias. SQL: ' . $sql);
-        
+        $this->assertStringContainsString('left join', $sql, 'Query should use LEFT JOIN when optimization is enabled. SQL: '.$sql);
+        $this->assertStringContainsString('companies_for_company', $sql, 'Query should use consistent alias. SQL: '.$sql);
+
         // Verify no subquery is used - check for general subquery pattern
-        $this->assertStringNotContainsString('select "companies"', $sql, 'Query should not contain subquery when JOINs are enabled. SQL: ' . $sql);
+        $this->assertStringNotContainsString('select "companies"', $sql, 'Query should not contain subquery when JOINs are enabled. SQL: '.$sql);
     }
 
     #[Test]
@@ -320,7 +316,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Ensure JOIN optimization is disabled (default behavior)
         config(['restify.search.use_joins' => false]);
-        
+
         UserRepository::$search = ['name'];
         UserRepository::$related = [
             'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
@@ -337,15 +333,15 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
             ->assertOk();
 
         $queries = DB::getQueryLog();
-        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'legacycorp'));
+        $searchQuery = collect($queries)->first(fn ($query) => str_contains(strtolower($query['query']), 'legacycorp'));
 
         $this->assertNotNull($searchQuery, 'Search query should be executed');
-        
+
         // Verify subquery is used (legacy behavior)
         $sql = strtolower($searchQuery['query']);
-        $this->assertStringNotContainsString('left join', $sql, 'Query should not use LEFT JOIN when optimization is disabled. SQL: ' . $sql);
-        $this->assertStringContainsString('select', $sql, 'Query should contain subquery when JOINs are disabled. SQL: ' . $sql);
-        $this->assertStringContainsString('from "companies"', $sql, 'Query should contain subquery from companies table. SQL: ' . $sql);
+        $this->assertStringNotContainsString('left join', $sql, 'Query should not use LEFT JOIN when optimization is disabled. SQL: '.$sql);
+        $this->assertStringContainsString('select', $sql, 'Query should contain subquery when JOINs are disabled. SQL: '.$sql);
+        $this->assertStringContainsString('from "companies"', $sql, 'Query should contain subquery from companies table. SQL: '.$sql);
     }
 
     #[Test]
@@ -353,7 +349,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
-        
+
         UserRepository::$search = ['name', 'email']; // Direct fields only, no relationships
         UserRepository::$related = [];
 
@@ -365,14 +361,14 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
             ->assertOk();
 
         $queries = DB::getQueryLog();
-        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'directsearch'));
+        $searchQuery = collect($queries)->first(fn ($query) => str_contains(strtolower($query['query']), 'directsearch'));
 
         $this->assertNotNull($searchQuery, 'Search query should be executed');
-        
+
         // Verify no JOINs are used for direct field searches
         $sql = strtolower($searchQuery['query']);
         $this->assertStringNotContainsString('left join', $sql, 'Direct field searches should not use JOINs');
-        $this->assertStringNotContainsString('select', $sql . ' from', 'Direct field searches should not contain subqueries');
+        $this->assertStringNotContainsString('select', $sql.' from', 'Direct field searches should not contain subqueries');
     }
 
     #[Test]
@@ -380,7 +376,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
-        
+
         UserRepository::$search = ['name'];
         UserRepository::$related = [
             'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
@@ -396,14 +392,14 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
 
         $this->getJson(UserRepository::route(query: [
             'search' => 'JoinedCorp',
-            'related' => 'company'
+            'related' => 'company',
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should not have separate eager loading query for company since it's already joined
-        $companyEagerQueries = collect($queries)->filter(function($query) {
-            return str_contains($query['query'], 'select * from "companies"') && 
+        $companyEagerQueries = collect($queries)->filter(function ($query) {
+            return str_contains($query['query'], 'select * from "companies"') &&
                    str_contains($query['query'], 'where "companies"."id" in');
         });
 
@@ -415,7 +411,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Ensure JOIN optimization is disabled (default behavior)
         config(['restify.search.use_joins' => false]);
-        
+
         UserRepository::$search = ['name'];
         UserRepository::$related = [
             'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
@@ -431,14 +427,14 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
 
         $this->getJson(UserRepository::route(query: [
             'search' => 'EagerCorp',
-            'related' => 'company'
+            'related' => 'company',
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should have separate eager loading query for company since JOINs are disabled
-        $companyEagerQueries = collect($queries)->filter(function($query) {
-            return str_contains($query['query'], 'select * from "companies"') && 
+        $companyEagerQueries = collect($queries)->filter(function ($query) {
+            return str_contains($query['query'], 'select * from "companies"') &&
                    str_contains($query['query'], 'where "companies"."id" in');
         });
 
@@ -450,7 +446,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
-        
+
         PostRepository::$search = ['title'];
         PostRepository::$related = [
             'user' => BelongsTo::make('user', UserRepository::class)->searchable([
@@ -468,16 +464,16 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
             ->assertOk();
 
         $queries = DB::getQueryLog();
-        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'searchuser'));
+        $searchQuery = collect($queries)->first(fn ($query) => str_contains(strtolower($query['query']), 'searchuser'));
 
         $this->assertNotNull($searchQuery);
-        
+
         $sql = strtolower($searchQuery['query']);
-        
+
         // Should have single JOIN for the user relationship when optimization is enabled
         $joinCount = substr_count($sql, 'left join "users"');
         $this->assertEquals(1, $joinCount, 'Should have exactly one JOIN for user relationship when optimization is enabled');
-        
+
         // Should search on multiple fields from the joined table
         $this->assertStringContainsString('"users_for_user"."name"', $sql);
         $this->assertStringContainsString('"users_for_user"."email"', $sql);

--- a/tests/Controllers/Index/EagerLoadingOptimizationTest.php
+++ b/tests/Controllers/Index/EagerLoadingOptimizationTest.php
@@ -4,9 +4,6 @@ namespace Binaryk\LaravelRestify\Tests\Controllers\Index;
 
 use Binaryk\LaravelRestify\Fields\BelongsTo;
 use Binaryk\LaravelRestify\Fields\HasMany;
-use Binaryk\LaravelRestify\Tests\Database\Factories\CompanyFactory;
-use Binaryk\LaravelRestify\Tests\Database\Factories\PostFactory;
-use Binaryk\LaravelRestify\Tests\Database\Factories\UserFactory;
 use Binaryk\LaravelRestify\Tests\Fixtures\Company\Company;
 use Binaryk\LaravelRestify\Tests\Fixtures\Company\CompanyRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
@@ -25,14 +22,14 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         DB::enableQueryLog();
     }
 
     protected function tearDown(): void
     {
         DB::disableQueryLog();
-        
+
         parent::tearDown();
     }
 
@@ -55,12 +52,12 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should have exactly 2 queries:
         // 1. Select users
         // 2. Select companies (eager loaded)
-        $this->assertCount(2, $queries, 'Expected 2 queries but got ' . count($queries));
-        
+        $this->assertCount(2, $queries, 'Expected 2 queries but got '.count($queries));
+
         // Verify the second query is an IN query for companies
         $this->assertStringContainsString('where "companies"."id" in', $queries[1]['query']);
     }
@@ -89,14 +86,13 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should have exactly 3 queries:
         // 1. Select users
         // 2. Select companies (eager loaded)
         // 3. Select posts (eager loaded)
-        $this->assertCount(3, $queries, 'Expected 3 queries but got ' . count($queries));
+        $this->assertCount(3, $queries, 'Expected 3 queries but got '.count($queries));
     }
-
 
     #[Test]
     public function it_handles_nested_relationships_without_n_plus_one(): void
@@ -104,7 +100,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         PostRepository::$related = [
             'user' => BelongsTo::make('user', UserRepository::class),
         ];
-        
+
         UserRepository::$related = [
             'company' => BelongsTo::make('company', CompanyRepository::class),
         ];
@@ -125,12 +121,12 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should have exactly 3 queries:
         // 1. Select posts
         // 2. Select users (eager loaded)
         // 3. Select companies (eager loaded)
-        $this->assertCount(3, $queries, 'Expected 3 queries but got ' . count($queries));
+        $this->assertCount(3, $queries, 'Expected 3 queries but got '.count($queries));
     }
 
     #[Test]
@@ -142,10 +138,10 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
 
         $company = Company::factory()->create(['name' => 'Preloaded Company']);
         $user = User::factory()->for($company)->create();
-        
+
         // Manually load the relation
         $user->load('company');
-        
+
         // Mock the repository to use our preloaded user
         UserRepository::partialMock()
             ->shouldReceive('indexQuery')
@@ -158,11 +154,11 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should have only 1 query (to get the user)
         // The company should not be queried again since it's already loaded
-        $this->assertCount(1, $queries, 'Expected 1 query but got ' . count($queries));
-        
+        $this->assertCount(1, $queries, 'Expected 1 query but got '.count($queries));
+
         // Verify the response still includes the company data
         $response->assertJson([
             'data' => [
@@ -198,10 +194,10 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should still attempt to eager load (1 query for users, potentially queries for relations)
         $this->assertGreaterThanOrEqual(1, count($queries));
-        
+
         // Verify response handles null relationships correctly
         $response->assertJson([
             'data' => [
@@ -228,7 +224,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
 
         // Test first page
         DB::flushQueryLog();
-        
+
         $this->getJson(UserRepository::route(query: [
             'related' => 'company',
             'perPage' => 20,
@@ -236,10 +232,10 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $firstPageQueries = count(DB::getQueryLog());
-        
+
         // Test second page
         DB::flushQueryLog();
-        
+
         $this->getJson(UserRepository::route(query: [
             'related' => 'company',
             'perPage' => 20,
@@ -247,7 +243,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         ]))->assertOk();
 
         $secondPageQueries = count(DB::getQueryLog());
-        
+
         // Both pages should have the same number of queries (no N+1)
         $this->assertEquals($firstPageQueries, $secondPageQueries);
         $this->assertEquals(2, $secondPageQueries); // Users + Companies
@@ -258,7 +254,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
-        
+
         UserRepository::$search = ['name'];
         UserRepository::$related = [
             'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
@@ -275,18 +271,18 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
             ->assertOk();
 
         $queries = DB::getQueryLog();
-        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'techcorp'));
+        $searchQuery = collect($queries)->first(fn ($query) => str_contains(strtolower($query['query']), 'techcorp'));
 
         $this->assertNotNull($searchQuery, 'Search query should be executed');
-        
+
         // Verify JOIN is used instead of subquery
         $sql = strtolower($searchQuery['query']);
         $this->assertStringContainsString('left join', $sql, 'Query should use LEFT JOIN when optimization is enabled');
         $this->assertStringContainsString('companies_for_company', $sql, 'Query should use consistent alias');
-        
+
         // Verify no subquery is used
         $this->assertStringNotContainsString('select * from "companies" where', $sql, 'Query should not contain subquery when JOINs are enabled');
-        
+
         // Reset config
         config(['restify.search.use_joins' => false]);
     }
@@ -296,7 +292,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Ensure JOIN optimization is disabled (default behavior)
         config(['restify.search.use_joins' => false]);
-        
+
         UserRepository::$search = ['name'];
         UserRepository::$related = [
             'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
@@ -313,10 +309,10 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
             ->assertOk();
 
         $queries = DB::getQueryLog();
-        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'legacycorp'));
+        $searchQuery = collect($queries)->first(fn ($query) => str_contains(strtolower($query['query']), 'legacycorp'));
 
         $this->assertNotNull($searchQuery, 'Search query should be executed');
-        
+
         // Verify subquery is used (legacy behavior)
         $sql = strtolower($searchQuery['query']);
         $this->assertStringNotContainsString('left join', $sql, 'Query should not use LEFT JOIN when optimization is disabled');
@@ -328,7 +324,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
-        
+
         UserRepository::$search = ['name', 'email']; // Direct fields only, no relationships
         UserRepository::$related = [];
 
@@ -340,15 +336,15 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
             ->assertOk();
 
         $queries = DB::getQueryLog();
-        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'directsearch'));
+        $searchQuery = collect($queries)->first(fn ($query) => str_contains(strtolower($query['query']), 'directsearch'));
 
         $this->assertNotNull($searchQuery, 'Search query should be executed');
-        
+
         // Verify no JOINs are used for direct field searches
         $sql = strtolower($searchQuery['query']);
         $this->assertStringNotContainsString('left join', $sql, 'Direct field searches should not use JOINs');
-        $this->assertStringNotContainsString('select', $sql . ' from', 'Direct field searches should not contain subqueries');
-        
+        $this->assertStringNotContainsString('select', $sql.' from', 'Direct field searches should not contain subqueries');
+
         // Reset config
         config(['restify.search.use_joins' => false]);
     }
@@ -358,7 +354,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
-        
+
         UserRepository::$search = ['name'];
         UserRepository::$related = [
             'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
@@ -374,19 +370,19 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
 
         $this->getJson(UserRepository::route(query: [
             'search' => 'JoinedCorp',
-            'related' => 'company'
+            'related' => 'company',
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should not have separate eager loading query for company since it's already joined
-        $companyEagerQueries = collect($queries)->filter(function($query) {
-            return str_contains($query['query'], 'select * from "companies"') && 
+        $companyEagerQueries = collect($queries)->filter(function ($query) {
+            return str_contains($query['query'], 'select * from "companies"') &&
                    str_contains($query['query'], 'where "companies"."id" in');
         });
 
         $this->assertCount(0, $companyEagerQueries, 'Should not eager load joined relationships when JOIN optimization is enabled');
-        
+
         // Reset config
         config(['restify.search.use_joins' => false]);
     }
@@ -396,7 +392,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Ensure JOIN optimization is disabled (default behavior)
         config(['restify.search.use_joins' => false]);
-        
+
         UserRepository::$search = ['name'];
         UserRepository::$related = [
             'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
@@ -412,14 +408,14 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
 
         $this->getJson(UserRepository::route(query: [
             'search' => 'EagerCorp',
-            'related' => 'company'
+            'related' => 'company',
         ]))->assertOk();
 
         $queries = DB::getQueryLog();
-        
+
         // Should have separate eager loading query for company since JOINs are disabled
-        $companyEagerQueries = collect($queries)->filter(function($query) {
-            return str_contains($query['query'], 'select * from "companies"') && 
+        $companyEagerQueries = collect($queries)->filter(function ($query) {
+            return str_contains($query['query'], 'select * from "companies"') &&
                    str_contains($query['query'], 'where "companies"."id" in');
         });
 
@@ -431,7 +427,7 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
-        
+
         PostRepository::$search = ['title'];
         PostRepository::$related = [
             'user' => BelongsTo::make('user', UserRepository::class)->searchable([
@@ -449,20 +445,20 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
             ->assertOk();
 
         $queries = DB::getQueryLog();
-        $searchQuery = collect($queries)->first(fn($query) => str_contains(strtolower($query['query']), 'searchuser'));
+        $searchQuery = collect($queries)->first(fn ($query) => str_contains(strtolower($query['query']), 'searchuser'));
 
         $this->assertNotNull($searchQuery);
-        
+
         $sql = strtolower($searchQuery['query']);
-        
+
         // Should have single JOIN for the user relationship when optimization is enabled
         $joinCount = substr_count($sql, 'left join "users"');
         $this->assertEquals(1, $joinCount, 'Should have exactly one JOIN for user relationship when optimization is enabled');
-        
+
         // Should search on multiple fields from the joined table
         $this->assertStringContainsString('"users_for_user"."name"', $sql);
         $this->assertStringContainsString('"users_for_user"."email"', $sql);
-        
+
         // Reset config
         config(['restify.search.use_joins' => false]);
     }

--- a/tests/Controllers/Index/EagerLoadingOptimizationTest.php
+++ b/tests/Controllers/Index/EagerLoadingOptimizationTest.php
@@ -26,12 +26,34 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
     {
         parent::setUp();
         
+        // Reset repository configurations before each test
+        UserRepository::$search = [];
+        UserRepository::$related = [];
+        UserRepository::$with = [];
+        PostRepository::$search = [];
+        PostRepository::$related = [];
+        PostRepository::$with = [];
+        
+        // Reset config to default
+        config(['restify.search.use_joins' => false]);
+        
         DB::enableQueryLog();
     }
 
     protected function tearDown(): void
     {
         DB::disableQueryLog();
+        
+        // Clean up repository configurations after each test
+        UserRepository::$search = [];
+        UserRepository::$related = [];
+        UserRepository::$with = [];
+        PostRepository::$search = [];
+        PostRepository::$related = [];
+        PostRepository::$with = [];
+        
+        // Reset config to default
+        config(['restify.search.use_joins' => false]);
         
         parent::tearDown();
     }
@@ -279,16 +301,18 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
 
         $this->assertNotNull($searchQuery, 'Search query should be executed');
         
+        // Debug: dump the actual query to see its structure
+        if (!$searchQuery) {
+            $this->fail('No search query found. Queries: ' . json_encode($queries));
+        }
+        
         // Verify JOIN is used instead of subquery
         $sql = strtolower($searchQuery['query']);
-        $this->assertStringContainsString('left join', $sql, 'Query should use LEFT JOIN when optimization is enabled');
-        $this->assertStringContainsString('companies_for_company', $sql, 'Query should use consistent alias');
+        $this->assertStringContainsString('left join', $sql, 'Query should use LEFT JOIN when optimization is enabled. SQL: ' . $sql);
+        $this->assertStringContainsString('companies_for_company', $sql, 'Query should use consistent alias. SQL: ' . $sql);
         
-        // Verify no subquery is used
-        $this->assertStringNotContainsString('select * from "companies" where', $sql, 'Query should not contain subquery when JOINs are enabled');
-        
-        // Reset config
-        config(['restify.search.use_joins' => false]);
+        // Verify no subquery is used - check for general subquery pattern
+        $this->assertStringNotContainsString('select "companies"', $sql, 'Query should not contain subquery when JOINs are enabled. SQL: ' . $sql);
     }
 
     #[Test]
@@ -319,8 +343,9 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         
         // Verify subquery is used (legacy behavior)
         $sql = strtolower($searchQuery['query']);
-        $this->assertStringNotContainsString('left join', $sql, 'Query should not use LEFT JOIN when optimization is disabled');
-        $this->assertStringContainsString('select "companies"."name" from "companies"', $sql, 'Query should contain subquery when JOINs are disabled');
+        $this->assertStringNotContainsString('left join', $sql, 'Query should not use LEFT JOIN when optimization is disabled. SQL: ' . $sql);
+        $this->assertStringContainsString('select', $sql, 'Query should contain subquery when JOINs are disabled. SQL: ' . $sql);
+        $this->assertStringContainsString('from "companies"', $sql, 'Query should contain subquery from companies table. SQL: ' . $sql);
     }
 
     #[Test]
@@ -348,9 +373,6 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         $sql = strtolower($searchQuery['query']);
         $this->assertStringNotContainsString('left join', $sql, 'Direct field searches should not use JOINs');
         $this->assertStringNotContainsString('select', $sql . ' from', 'Direct field searches should not contain subqueries');
-        
-        // Reset config
-        config(['restify.search.use_joins' => false]);
     }
 
     #[Test]
@@ -386,9 +408,6 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         });
 
         $this->assertCount(0, $companyEagerQueries, 'Should not eager load joined relationships when JOIN optimization is enabled');
-        
-        // Reset config
-        config(['restify.search.use_joins' => false]);
     }
 
     #[Test]
@@ -462,8 +481,5 @@ class EagerLoadingOptimizationTest extends IntegrationTestCase
         // Should search on multiple fields from the joined table
         $this->assertStringContainsString('"users_for_user"."name"', $sql);
         $this->assertStringContainsString('"users_for_user"."email"', $sql);
-        
-        // Reset config
-        config(['restify.search.use_joins' => false]);
     }
 }

--- a/tests/Unit/RelatedEagerLoadingTest.php
+++ b/tests/Unit/RelatedEagerLoadingTest.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Unit;
+
+use Binaryk\LaravelRestify\Eager\Related;
+use Binaryk\LaravelRestify\Fields\BelongsTo;
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Binaryk\LaravelRestify\Tests\Fixtures\Company\Company;
+use Binaryk\LaravelRestify\Tests\Fixtures\Company\CompanyRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
+use Binaryk\LaravelRestify\Tests\IntegrationTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+
+class RelatedEagerLoadingTest extends IntegrationTestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_uses_eager_loaded_relation_when_available(): void
+    {
+        $company = Company::factory()->create(['name' => 'Eager Company']);
+        $user = User::factory()->for($company)->create();
+        
+        // Manually load the relation
+        $user->load('company');
+        
+        $repository = UserRepository::resolveWith($user);
+        $related = new Related('company');
+        
+        $request = Mockery::mock(RestifyRequest::class);
+        $request->shouldReceive('related->resolved')->once();
+        
+        // Resolve the related field
+        $related->resolve($request, $repository);
+        
+        // Verify it returns the already loaded company
+        $this->assertInstanceOf(Company::class, $related->getValue());
+        $this->assertEquals('Eager Company', $related->getValue()->name);
+        
+        // Verify the relation was already loaded (no new query)
+        $this->assertTrue($user->relationLoaded('company'));
+    }
+
+    #[Test]
+    public function it_makes_query_when_relation_not_loaded(): void
+    {
+        $company = Company::factory()->create(['name' => 'Lazy Company']);
+        $user = User::factory()->for($company)->create();
+        
+        // Do NOT load the relation
+        $this->assertFalse($user->relationLoaded('company'));
+        
+        $repository = UserRepository::resolveWith($user);
+        $related = new Related('company');
+        
+        $request = Mockery::mock(RestifyRequest::class);
+        $request->shouldReceive('related->resolved')->once();
+        
+        // Resolve the related field
+        $related->resolve($request, $repository);
+        
+        // Verify it still returns the company (via query)
+        $this->assertInstanceOf(Company::class, $related->getValue());
+        $this->assertEquals('Lazy Company', $related->getValue()->name);
+    }
+
+    #[Test]
+    public function it_handles_collection_relations_when_eager_loaded(): void
+    {
+        $user = User::factory()->create();
+        $posts = \Binaryk\LaravelRestify\Tests\Fixtures\Post\Post::factory()->count(3)->create([
+            'user_id' => $user->id,
+        ]);
+        
+        // Manually load the posts relation
+        $user->load('posts');
+        
+        $repository = UserRepository::resolveWith($user);
+        $related = new Related('posts');
+        
+        $request = Mockery::mock(RestifyRequest::class);
+        $request->shouldReceive('related->resolved')->once();
+        
+        // Resolve the related field
+        $related->resolve($request, $repository);
+        
+        // Verify it returns the collection
+        $this->assertInstanceOf(Collection::class, $related->getValue());
+        $this->assertCount(3, $related->getValue());
+        $this->assertTrue($user->relationLoaded('posts'));
+    }
+
+    #[Test]
+    public function it_handles_null_relations(): void
+    {
+        $user = User::factory()->create(['company_id' => null]);
+        
+        // Load the empty relation
+        $user->load('company');
+        
+        $repository = UserRepository::resolveWith($user);
+        $related = new Related('company');
+        
+        $request = Mockery::mock(RestifyRequest::class);
+        $request->shouldReceive('related->resolved')->once();
+        
+        // Resolve the related field
+        $related->resolve($request, $repository);
+        
+        // Verify it handles null correctly
+        $this->assertNull($related->getValue());
+    }
+
+
+    #[Test]
+    public function it_handles_eager_field_relations(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->for($company)->create();
+        
+        $repository = UserRepository::resolveWith($user);
+        
+        // Create an eager field
+        $eagerField = BelongsTo::make('company', CompanyRepository::class);
+        $related = new Related('company', $eagerField);
+        
+        $request = Mockery::mock(RestifyRequest::class);
+        $request->shouldReceive('related->resolved')->once();
+        
+        // Resolve the related field
+        $related->resolve($request, $repository);
+        
+        // Verify it's recognized as eager
+        $this->assertTrue($related->isEager());
+    }
+
+    #[Test]
+    public function it_handles_nested_relations_with_dot_notation(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->for($company)->create();
+        $posts = \Binaryk\LaravelRestify\Tests\Fixtures\Post\Post::factory()->count(2)->create([
+            'user_id' => $user->id,
+        ]);
+        
+        // Load nested relation
+        $user->load('posts.user');
+        
+        $repository = UserRepository::resolveWith($user);
+        $related = new Related('posts.user');
+        
+        $request = Mockery::mock(RestifyRequest::class);
+        $request->shouldReceive('related->resolved')->once();
+        
+        // Resolve the related field
+        $related->resolve($request, $repository);
+        
+        // For nested relations, it returns the first level
+        $value = $related->getValue();
+        $this->assertIsArray($value);
+    }
+
+    #[Test]
+    public function it_uses_custom_resolver_callback(): void
+    {
+        $user = User::factory()->create();
+        $repository = UserRepository::resolveWith($user);
+        
+        $related = new Related('custom');
+        $related->resolveUsing(function ($request, $repo) {
+            $this->assertInstanceOf(RestifyRequest::class, $request);
+            $this->assertInstanceOf(UserRepository::class, $repo);
+            return 'custom-value';
+        });
+        
+        $request = Mockery::mock(RestifyRequest::class);
+        $request->shouldReceive('related->resolved')->once();
+        
+        // Resolve the related field
+        $related->resolve($request, $repository);
+        
+        // Verify custom resolver was used
+        $this->assertEquals('custom-value', $related->getValue());
+    }
+
+    #[Test]
+    public function search_with_join_optimization_reduces_query_count_when_enabled(): void
+    {
+        // Enable JOIN optimization
+        config(['restify.search.use_joins' => true]);
+        
+        // Create test data
+        $companies = Company::factory()->count(5)->create();
+        foreach ($companies as $company) {
+            User::factory()->count(10)->for($company)->create();
+        }
+
+        // Configure repository with searchable BelongsTo relationship
+        UserRepository::$search = ['name'];
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
+                'companies.name',
+            ]),
+        ];
+
+        \Illuminate\Support\Facades\DB::enableQueryLog();
+        
+        // Perform search that would trigger related field search
+        $response = $this->getJson(UserRepository::route(query: [
+            'search' => $companies->first()->name,
+            'perPage' => 50
+        ]));
+
+        $queries = \Illuminate\Support\Facades\DB::getQueryLog();
+        \Illuminate\Support\Facades\DB::disableQueryLog();
+
+        $response->assertSuccessful();
+        
+        // With JOIN optimization, we should have minimal queries:
+        // 1. Main search query with JOIN
+        // 2. Potentially count query
+        $this->assertLessThan(4, count($queries), 
+            'Expected fewer than 4 queries with JOIN optimization, got: ' . count($queries)
+        );
+
+        // Verify that the main query uses JOIN when optimization is enabled
+        $searchQuery = collect($queries)->first(function ($query) use ($companies) {
+            return str_contains(strtolower($query['query']), strtolower($companies->first()->name));
+        });
+
+        $this->assertNotNull($searchQuery, 'Search query should be found');
+        $this->assertStringContainsString('left join', strtolower($searchQuery['query']), 
+            'Search query should use LEFT JOIN when optimization is enabled'
+        );
+        
+        // Clean up
+        UserRepository::$search = [];
+        UserRepository::$related = [];
+        config(['restify.search.use_joins' => false]);
+    }
+
+    #[Test]
+    public function joined_relationships_excluded_from_eager_loading_when_optimization_enabled(): void
+    {
+        // Enable JOIN optimization
+        config(['restify.search.use_joins' => true]);
+        
+        $company = Company::factory()->create(['name' => 'TestCompany']);
+        User::factory()->count(10)->for($company)->create();
+
+        UserRepository::$search = ['name'];
+        UserRepository::$related = [
+            'company' => BelongsTo::make('company', CompanyRepository::class)->searchable([
+                'companies.name',
+            ]),
+        ];
+        UserRepository::$with = ['company']; // This should be optimized away when JOINs are enabled
+
+        \Illuminate\Support\Facades\DB::enableQueryLog();
+
+        $response = $this->getJson(UserRepository::route(query: [
+            'search' => 'TestCompany',
+            'related' => 'company',
+            'perPage' => 10
+        ]));
+
+        $queries = \Illuminate\Support\Facades\DB::getQueryLog();
+        \Illuminate\Support\Facades\DB::disableQueryLog();
+
+        $response->assertSuccessful();
+
+        // Check that there's no separate eager loading query for company
+        // since it's already joined in the main query when optimization is enabled
+        $eagerLoadingQueries = collect($queries)->filter(function ($query) {
+            return str_contains($query['query'], 'select * from "companies"') &&
+                   str_contains($query['query'], 'where "companies"."id" in');
+        });
+
+        $this->assertCount(0, $eagerLoadingQueries, 
+            'Should not execute separate eager loading query for joined relationship when optimization is enabled'
+        );
+        
+        // Clean up
+        UserRepository::$search = [];
+        UserRepository::$related = [];
+        UserRepository::$with = [];
+        config(['restify.search.use_joins' => false]);
+    }
+}

--- a/tests/Unit/RelatedEagerLoadingTest.php
+++ b/tests/Unit/RelatedEagerLoadingTest.php
@@ -24,23 +24,23 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
     {
         $company = Company::factory()->create(['name' => 'Eager Company']);
         $user = User::factory()->for($company)->create();
-        
+
         // Manually load the relation
         $user->load('company');
-        
+
         $repository = UserRepository::resolveWith($user);
         $related = new Related('company');
-        
+
         $request = Mockery::mock(RestifyRequest::class);
         $request->shouldReceive('related->resolved')->once();
-        
+
         // Resolve the related field
         $related->resolve($request, $repository);
-        
+
         // Verify it returns the already loaded company
         $this->assertInstanceOf(Company::class, $related->getValue());
         $this->assertEquals('Eager Company', $related->getValue()->name);
-        
+
         // Verify the relation was already loaded (no new query)
         $this->assertTrue($user->relationLoaded('company'));
     }
@@ -50,19 +50,19 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
     {
         $company = Company::factory()->create(['name' => 'Lazy Company']);
         $user = User::factory()->for($company)->create();
-        
+
         // Do NOT load the relation
         $this->assertFalse($user->relationLoaded('company'));
-        
+
         $repository = UserRepository::resolveWith($user);
         $related = new Related('company');
-        
+
         $request = Mockery::mock(RestifyRequest::class);
         $request->shouldReceive('related->resolved')->once();
-        
+
         // Resolve the related field
         $related->resolve($request, $repository);
-        
+
         // Verify it still returns the company (via query)
         $this->assertInstanceOf(Company::class, $related->getValue());
         $this->assertEquals('Lazy Company', $related->getValue()->name);
@@ -75,19 +75,19 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
         $posts = \Binaryk\LaravelRestify\Tests\Fixtures\Post\Post::factory()->count(3)->create([
             'user_id' => $user->id,
         ]);
-        
+
         // Manually load the posts relation
         $user->load('posts');
-        
+
         $repository = UserRepository::resolveWith($user);
         $related = new Related('posts');
-        
+
         $request = Mockery::mock(RestifyRequest::class);
         $request->shouldReceive('related->resolved')->once();
-        
+
         // Resolve the related field
         $related->resolve($request, $repository);
-        
+
         // Verify it returns the collection
         $this->assertInstanceOf(Collection::class, $related->getValue());
         $this->assertCount(3, $related->getValue());
@@ -98,42 +98,41 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
     public function it_handles_null_relations(): void
     {
         $user = User::factory()->create(['company_id' => null]);
-        
+
         // Load the empty relation
         $user->load('company');
-        
+
         $repository = UserRepository::resolveWith($user);
         $related = new Related('company');
-        
+
         $request = Mockery::mock(RestifyRequest::class);
         $request->shouldReceive('related->resolved')->once();
-        
+
         // Resolve the related field
         $related->resolve($request, $repository);
-        
+
         // Verify it handles null correctly
         $this->assertNull($related->getValue());
     }
-
 
     #[Test]
     public function it_handles_eager_field_relations(): void
     {
         $company = Company::factory()->create();
         $user = User::factory()->for($company)->create();
-        
+
         $repository = UserRepository::resolveWith($user);
-        
+
         // Create an eager field
         $eagerField = BelongsTo::make('company', CompanyRepository::class);
         $related = new Related('company', $eagerField);
-        
+
         $request = Mockery::mock(RestifyRequest::class);
         $request->shouldReceive('related->resolved')->once();
-        
+
         // Resolve the related field
         $related->resolve($request, $repository);
-        
+
         // Verify it's recognized as eager
         $this->assertTrue($related->isEager());
     }
@@ -146,19 +145,19 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
         $posts = \Binaryk\LaravelRestify\Tests\Fixtures\Post\Post::factory()->count(2)->create([
             'user_id' => $user->id,
         ]);
-        
+
         // Load nested relation
         $user->load('posts.user');
-        
+
         $repository = UserRepository::resolveWith($user);
         $related = new Related('posts.user');
-        
+
         $request = Mockery::mock(RestifyRequest::class);
         $request->shouldReceive('related->resolved')->once();
-        
+
         // Resolve the related field
         $related->resolve($request, $repository);
-        
+
         // For nested relations, it returns the first level
         $value = $related->getValue();
         $this->assertIsArray($value);
@@ -169,20 +168,21 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
     {
         $user = User::factory()->create();
         $repository = UserRepository::resolveWith($user);
-        
+
         $related = new Related('custom');
         $related->resolveUsing(function ($request, $repo) {
             $this->assertInstanceOf(RestifyRequest::class, $request);
             $this->assertInstanceOf(UserRepository::class, $repo);
+
             return 'custom-value';
         });
-        
+
         $request = Mockery::mock(RestifyRequest::class);
         $request->shouldReceive('related->resolved')->once();
-        
+
         // Resolve the related field
         $related->resolve($request, $repository);
-        
+
         // Verify custom resolver was used
         $this->assertEquals('custom-value', $related->getValue());
     }
@@ -192,7 +192,7 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
     {
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
-        
+
         // Create test data
         $companies = Company::factory()->count(5)->create();
         foreach ($companies as $company) {
@@ -208,23 +208,23 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
         ];
 
         \Illuminate\Support\Facades\DB::enableQueryLog();
-        
+
         // Perform search that would trigger related field search
         $response = $this->getJson(UserRepository::route(query: [
             'search' => $companies->first()->name,
-            'perPage' => 50
+            'perPage' => 50,
         ]));
 
         $queries = \Illuminate\Support\Facades\DB::getQueryLog();
         \Illuminate\Support\Facades\DB::disableQueryLog();
 
         $response->assertSuccessful();
-        
+
         // With JOIN optimization, we should have minimal queries:
         // 1. Main search query with JOIN
         // 2. Potentially count query
-        $this->assertLessThan(4, count($queries), 
-            'Expected fewer than 4 queries with JOIN optimization, got: ' . count($queries)
+        $this->assertLessThan(4, count($queries),
+            'Expected fewer than 4 queries with JOIN optimization, got: '.count($queries)
         );
 
         // Verify that the main query uses JOIN when optimization is enabled
@@ -233,10 +233,10 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
         });
 
         $this->assertNotNull($searchQuery, 'Search query should be found');
-        $this->assertStringContainsString('left join', strtolower($searchQuery['query']), 
+        $this->assertStringContainsString('left join', strtolower($searchQuery['query']),
             'Search query should use LEFT JOIN when optimization is enabled'
         );
-        
+
         // Clean up
         UserRepository::$search = [];
         UserRepository::$related = [];
@@ -248,7 +248,7 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
     {
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
-        
+
         $company = Company::factory()->create(['name' => 'TestCompany']);
         User::factory()->count(10)->for($company)->create();
 
@@ -265,7 +265,7 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
         $response = $this->getJson(UserRepository::route(query: [
             'search' => 'TestCompany',
             'related' => 'company',
-            'perPage' => 10
+            'perPage' => 10,
         ]));
 
         $queries = \Illuminate\Support\Facades\DB::getQueryLog();
@@ -280,10 +280,10 @@ class RelatedEagerLoadingTest extends IntegrationTestCase
                    str_contains($query['query'], 'where "companies"."id" in');
         });
 
-        $this->assertCount(0, $eagerLoadingQueries, 
+        $this->assertCount(0, $eagerLoadingQueries,
             'Should not execute separate eager loading query for joined relationship when optimization is enabled'
         );
-        
+
         // Clean up
         UserRepository::$search = [];
         UserRepository::$related = [];

--- a/tests/Unit/SearchableFilterTest.php
+++ b/tests/Unit/SearchableFilterTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Unit;
+
+use Binaryk\LaravelRestify\Fields\BelongsTo;
+use Binaryk\LaravelRestify\Filters\SearchableFilter;
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Binaryk\LaravelRestify\Tests\Fixtures\Company\Company;
+use Binaryk\LaravelRestify\Tests\Fixtures\Company\CompanyRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
+use Binaryk\LaravelRestify\Tests\IntegrationTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+
+class SearchableFilterTest extends IntegrationTestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        // Reset config to default
+        config(['restify.search.use_joins' => false]);
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset config to default
+        config(['restify.search.use_joins' => false]);
+        
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_uses_subqueries_by_default(): void
+    {
+        // Ensure JOIN optimization is disabled (default)
+        $this->assertFalse(config('restify.search.use_joins'));
+        
+        $company = Company::factory()->create(['name' => 'TestCompany']);
+        $user = User::factory()->for($company)->create();
+        
+        $repository = UserRepository::resolveWith($user);
+        $belongsToField = BelongsTo::make('company', CompanyRepository::class)->searchable(['companies.name']);
+        
+        $filter = SearchableFilter::make()->setRepository($repository)->usingBelongsTo($belongsToField);
+        
+        $query = User::query();
+        $request = Mockery::mock(RestifyRequest::class);
+        
+        DB::enableQueryLog();
+        $filter->filter($request, $query, 'TestCompany');
+        $sql = $query->toSql();
+        DB::disableQueryLog();
+        
+        // Should contain subquery pattern
+        $this->assertStringContainsString('select', strtolower($sql));
+        $this->assertStringContainsString('where', strtolower($sql));
+        
+        // Should NOT contain JOIN
+        $this->assertStringNotContainsString('join', strtolower($sql));
+    }
+
+    #[Test]
+    public function it_uses_joins_when_enabled(): void
+    {
+        // Enable JOIN optimization
+        config(['restify.search.use_joins' => true]);
+        $this->assertTrue(config('restify.search.use_joins'));
+        
+        $company = Company::factory()->create(['name' => 'TestCompany']);
+        $user = User::factory()->for($company)->create();
+        
+        $repository = UserRepository::resolveWith($user);
+        $belongsToField = BelongsTo::make('company', CompanyRepository::class)->searchable(['companies.name']);
+        
+        $filter = SearchableFilter::make()->setRepository($repository)->usingBelongsTo($belongsToField);
+        
+        $query = User::query();
+        $request = Mockery::mock(RestifyRequest::class);
+        
+        DB::enableQueryLog();
+        $filter->filter($request, $query, 'TestCompany');
+        $sql = $query->toSql();
+        DB::disableQueryLog();
+        
+        // Should contain JOIN pattern
+        $this->assertStringContainsString('left join', strtolower($sql));
+        $this->assertStringContainsString('companies_for_company', strtolower($sql));
+        
+        // Should NOT contain subquery
+        $this->assertStringNotContainsString('select "name" from "companies"', strtolower($sql));
+    }
+
+    #[Test]
+    public function it_handles_direct_fields_without_joins(): void
+    {
+        // Enable JOIN optimization
+        config(['restify.search.use_joins' => true]);
+        
+        $user = User::factory()->create(['name' => 'TestUser']);
+        $repository = UserRepository::resolveWith($user);
+        
+        // Create filter for direct field (no BelongsTo)
+        $filter = SearchableFilter::make()->setRepository($repository)->setColumn('users.name');
+        
+        $query = User::query();
+        $request = Mockery::mock(RestifyRequest::class);
+        
+        DB::enableQueryLog();
+        $filter->filter($request, $query, 'TestUser');
+        $sql = $query->toSql();
+        DB::disableQueryLog();
+        
+        // Should NOT contain JOIN for direct fields
+        $this->assertStringNotContainsString('join', strtolower($sql));
+        
+        // Should contain simple WHERE clause
+        $this->assertStringContainsString('where', strtolower($sql));
+        $this->assertStringContainsString('like', strtolower($sql));
+    }
+}

--- a/tests/Unit/SearchableFilterTest.php
+++ b/tests/Unit/SearchableFilterTest.php
@@ -22,7 +22,7 @@ class SearchableFilterTest extends IntegrationTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         // Reset config to default
         config(['restify.search.use_joins' => false]);
     }
@@ -31,7 +31,7 @@ class SearchableFilterTest extends IntegrationTestCase
     {
         // Reset config to default
         config(['restify.search.use_joins' => false]);
-        
+
         parent::tearDown();
     }
 
@@ -40,27 +40,27 @@ class SearchableFilterTest extends IntegrationTestCase
     {
         // Ensure JOIN optimization is disabled (default)
         $this->assertFalse(config('restify.search.use_joins'));
-        
+
         $company = Company::factory()->create(['name' => 'TestCompany']);
         $user = User::factory()->for($company)->create();
-        
+
         $repository = UserRepository::resolveWith($user);
         $belongsToField = BelongsTo::make('company', CompanyRepository::class)->searchable(['companies.name']);
-        
+
         $filter = SearchableFilter::make()->setRepository($repository)->usingBelongsTo($belongsToField);
-        
+
         $query = User::query();
         $request = Mockery::mock(RestifyRequest::class);
-        
+
         DB::enableQueryLog();
         $filter->filter($request, $query, 'TestCompany');
         $sql = $query->toSql();
         DB::disableQueryLog();
-        
+
         // Should contain subquery pattern
         $this->assertStringContainsString('select', strtolower($sql));
         $this->assertStringContainsString('where', strtolower($sql));
-        
+
         // Should NOT contain JOIN
         $this->assertStringNotContainsString('join', strtolower($sql));
     }
@@ -71,27 +71,27 @@ class SearchableFilterTest extends IntegrationTestCase
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
         $this->assertTrue(config('restify.search.use_joins'));
-        
+
         $company = Company::factory()->create(['name' => 'TestCompany']);
         $user = User::factory()->for($company)->create();
-        
+
         $repository = UserRepository::resolveWith($user);
         $belongsToField = BelongsTo::make('company', CompanyRepository::class)->searchable(['companies.name']);
-        
+
         $filter = SearchableFilter::make()->setRepository($repository)->usingBelongsTo($belongsToField);
-        
+
         $query = User::query();
         $request = Mockery::mock(RestifyRequest::class);
-        
+
         DB::enableQueryLog();
         $filter->filter($request, $query, 'TestCompany');
         $sql = $query->toSql();
         DB::disableQueryLog();
-        
+
         // Should contain JOIN pattern
         $this->assertStringContainsString('left join', strtolower($sql));
         $this->assertStringContainsString('companies_for_company', strtolower($sql));
-        
+
         // Should NOT contain subquery
         $this->assertStringNotContainsString('select "name" from "companies"', strtolower($sql));
     }
@@ -101,24 +101,24 @@ class SearchableFilterTest extends IntegrationTestCase
     {
         // Enable JOIN optimization
         config(['restify.search.use_joins' => true]);
-        
+
         $user = User::factory()->create(['name' => 'TestUser']);
         $repository = UserRepository::resolveWith($user);
-        
+
         // Create filter for direct field (no BelongsTo)
         $filter = SearchableFilter::make()->setRepository($repository)->setColumn('users.name');
-        
+
         $query = User::query();
         $request = Mockery::mock(RestifyRequest::class);
-        
+
         DB::enableQueryLog();
         $filter->filter($request, $query, 'TestUser');
         $sql = $query->toSql();
         DB::disableQueryLog();
-        
+
         // Should NOT contain JOIN for direct fields
         $this->assertStringNotContainsString('join', strtolower($sql));
-        
+
         // Should contain simple WHERE clause
         $this->assertStringContainsString('where', strtolower($sql));
         $this->assertStringContainsString('like', strtolower($sql));


### PR DESCRIPTION
# Search Performance Optimization config option

## Overview

By default, when searching through BelongsTo relationship fields, Laravel Restify uses subqueries which can be slow for large datasets:

```sql
-- Default behavior (subqueries)
SELECT * FROM `invoices` WHERE (
    UPPER(`invoices`.`gross_amount`) LIKE '%CSC%'
    OR (SELECT `vendors`.`code` FROM `vendors` WHERE `vendors`.`id` = `invoices`.`vendor_id` LIMIT 1) LIKE '%csc%'
    OR (SELECT `vendors`.`name` FROM `vendors` WHERE `vendors`.`id` = `invoices`.`vendor_id` LIMIT 1) LIKE '%csc%'
)
```

With JOIN optimization enabled, these become efficient JOIN-based queries:

```sql
-- Optimized behavior (JOINs)
SELECT invoices.* FROM `invoices`
LEFT JOIN `vendors` AS vendors_for_vendor ON invoices.vendor_id = vendors_for_vendor.id
WHERE (
    UPPER(invoices.gross_amount) LIKE '%CSC%'
    OR UPPER(vendors_for_vendor.code) LIKE '%CSC%'
    OR UPPER(vendors_for_vendor.name) LIKE '%CSC%'
)
```

## Configuration

### Enabling JOIN Optimization

Add the following to your `.env` file:

```env
RESTIFY_SEARCH_USE_JOINS=true
```

Or configure it directly in `config/restify.php`:

```php
'search' => [
    'case_sensitive' => true,
    'use_joins' => true, // Enable JOIN optimization
],
```

### Default Behavior

**By default, JOIN optimization is disabled** to maintain backward compatibility. The system will continue using subqueries until explicitly enabled.