### PR TITLE
feat: Bump laravel/mcp to 0.4 to allow laravel/boost ^1.8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.3",
         "illuminate/contracts": "^11.0|^12.0",
         "laravel/framework": "^11.0|^12.0",
-        "laravel/mcp": "^0.2|^0.3.4",
+        "laravel/mcp": "^0.4.1",
         "laravel/pint": "^1.25.1",
         "spatie/laravel-data": "^4.4",
         "spatie/laravel-package-tools": "^1.12",
@@ -38,7 +38,7 @@
         "phpstan/phpstan-phpunit": "^1.0|^2.0",
         "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "spatie/laravel-ray": "^1.9",
-        "vimeo/psalm": "^6.0@dev"
+        "vimeo/psalm": "^6.0"
     },
     "suggest": {
         "nuwave/lighthouse": "For GraphQL schema generation and resolvers (^6.0)",

--- a/src/MCP/Tools/GlobalSearchTool.php
+++ b/src/MCP/Tools/GlobalSearchTool.php
@@ -6,7 +6,7 @@ use Binaryk\LaravelRestify\Filters\SearchablesCollection;
 use Binaryk\LaravelRestify\MCP\Requests\McpRequest;
 use Binaryk\LaravelRestify\Restify;
 use Binaryk\LaravelRestify\Services\Search\GlobalSearch;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Operations/ActionTool.php
+++ b/src/MCP/Tools/Operations/ActionTool.php
@@ -7,7 +7,7 @@ use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Binaryk\LaravelRestify\MCP\Concerns\HasMcpTools;
 use Binaryk\LaravelRestify\MCP\Requests\McpActionRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Operations/DeleteTool.php
+++ b/src/MCP/Tools/Operations/DeleteTool.php
@@ -5,7 +5,7 @@ namespace Binaryk\LaravelRestify\MCP\Tools\Operations;
 use Binaryk\LaravelRestify\MCP\Concerns\HasMcpTools;
 use Binaryk\LaravelRestify\MCP\Requests\McpDestroyRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Operations/GetterTool.php
+++ b/src/MCP/Tools/Operations/GetterTool.php
@@ -6,7 +6,7 @@ use Binaryk\LaravelRestify\Getters\Getter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Binaryk\LaravelRestify\MCP\Requests\McpGetterRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Operations/IndexTool.php
+++ b/src/MCP/Tools/Operations/IndexTool.php
@@ -5,7 +5,7 @@ namespace Binaryk\LaravelRestify\MCP\Tools\Operations;
 use Binaryk\LaravelRestify\MCP\Concerns\HasMcpTools;
 use Binaryk\LaravelRestify\MCP\Requests\McpIndexRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Operations/ProfileTool.php
+++ b/src/MCP/Tools/Operations/ProfileTool.php
@@ -4,7 +4,7 @@ namespace Binaryk\LaravelRestify\MCP\Tools\Operations;
 
 use Binaryk\LaravelRestify\MCP\Requests\McpIndexRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Operations/ShowTool.php
+++ b/src/MCP/Tools/Operations/ShowTool.php
@@ -5,7 +5,7 @@ namespace Binaryk\LaravelRestify\MCP\Tools\Operations;
 use Binaryk\LaravelRestify\MCP\Concerns\HasMcpTools;
 use Binaryk\LaravelRestify\MCP\Requests\McpShowRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Operations/StoreTool.php
+++ b/src/MCP/Tools/Operations/StoreTool.php
@@ -5,7 +5,7 @@ namespace Binaryk\LaravelRestify\MCP\Tools\Operations;
 use Binaryk\LaravelRestify\MCP\Concerns\HasMcpTools;
 use Binaryk\LaravelRestify\MCP\Requests\McpStoreRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Operations/UpdateTool.php
+++ b/src/MCP/Tools/Operations/UpdateTool.php
@@ -5,7 +5,7 @@ namespace Binaryk\LaravelRestify\MCP\Tools\Operations;
 use Binaryk\LaravelRestify\MCP\Concerns\HasMcpTools;
 use Binaryk\LaravelRestify\MCP\Requests\McpUpdateRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Wrapper/DiscoverRepositoriesTool.php
+++ b/src/MCP/Tools/Wrapper/DiscoverRepositoriesTool.php
@@ -4,7 +4,7 @@ namespace Binaryk\LaravelRestify\MCP\Tools\Wrapper;
 
 use Binaryk\LaravelRestify\MCP\Concerns\WrapperToolHelpers;
 use Binaryk\LaravelRestify\MCP\McpTools;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Wrapper/ExecuteOperationTool.php
+++ b/src/MCP/Tools/Wrapper/ExecuteOperationTool.php
@@ -4,7 +4,7 @@ namespace Binaryk\LaravelRestify\MCP\Tools\Wrapper;
 
 use Binaryk\LaravelRestify\MCP\Concerns\WrapperToolHelpers;
 use Binaryk\LaravelRestify\MCP\McpTools;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Wrapper/GetOperationDetailsTool.php
+++ b/src/MCP/Tools/Wrapper/GetOperationDetailsTool.php
@@ -4,7 +4,7 @@ namespace Binaryk\LaravelRestify\MCP\Tools\Wrapper;
 
 use Binaryk\LaravelRestify\MCP\Concerns\WrapperToolHelpers;
 use Binaryk\LaravelRestify\MCP\McpTools;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;

--- a/src/MCP/Tools/Wrapper/GetRepositoryOperationsTool.php
+++ b/src/MCP/Tools/Wrapper/GetRepositoryOperationsTool.php
@@ -4,7 +4,7 @@ namespace Binaryk\LaravelRestify\MCP\Tools\Wrapper;
 
 use Binaryk\LaravelRestify\MCP\Concerns\WrapperToolHelpers;
 use Binaryk\LaravelRestify\MCP\McpTools;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;


### PR DESCRIPTION
This is a breaking change as `laravel/mcp: 0.2 and 0.3` had a different folder / class structure