### PR TITLE
fix: MCP action resolver ignores operation_name, always runs first action

### DIFF
--- a/src/MCP/McpToolsManager.php
+++ b/src/MCP/McpToolsManager.php
@@ -326,7 +326,7 @@ class McpToolsManager
         // Find the tool
         $tool = $this->repository($repositoryKey)
             ->where('type', $operationTypeEnum)
-            ->when($operationName && in_array($operationType, [OperationTypeEnum::action, OperationTypeEnum::getter]), function ($collection) use ($operationName) {
+            ->when($operationName && in_array($operationTypeEnum, [OperationTypeEnum::action, OperationTypeEnum::getter]), function ($collection) use ($operationName) {
                 return $collection->filter(function ($tool) use ($operationName) {
                     if ($tool['type'] === OperationTypeEnum::action) {
                         return $tool['action']->uriKey() === $operationName;
@@ -378,7 +378,7 @@ class McpToolsManager
         // Find the tool
         $tool = $this->repository($repositoryKey)
             ->where('type', $operationTypeEnum)
-            ->when($operationName && in_array($operationType, [OperationTypeEnum::action, OperationTypeEnum::getter]), function ($collection) use ($operationName) {
+            ->when($operationName && in_array($operationTypeEnum, [OperationTypeEnum::action, OperationTypeEnum::getter]), function ($collection) use ($operationName) {
                 return $collection->filter(function ($tool) use ($operationName) {
                     if ($tool['type'] === OperationTypeEnum::action) {
                         return $tool['action']->uriKey() === $operationName;


### PR DESCRIPTION
## Bug

When calling `execute-operation` with `operation_type=action` and `operation_name=replicate`, the wrapper always executes the first action in the list (e.g., `share-invoice`) instead of the requested one.

Same issue affects the second code path used by action/getter resolution.

## Root Cause

`McpToolsManager::executeOperation()` line 381 compares the raw string `$operationType` (`'action'`) against enum cases (`OperationTypeEnum::action`) using `in_array()`. In PHP, a string never equals an enum case, so the comparison always returns `false`. The `->when()` filter never runs, and `->first()` returns index 0.

```php
// Before (bug): $operationType is a string, enum cases are not strings
->when($operationName && in_array($operationType, [OperationTypeEnum::action, ...]))

// After (fix): $operationTypeEnum is the converted enum
->when($operationName && in_array($operationTypeEnum, [OperationTypeEnum::action, ...]))
```

Note: `getOperationDetails()` had the same pattern at line 329 but was already using `$operationTypeEnum` correctly. The two instances fixed here are the second code path at line 378 and `executeOperation` at line 381.

## Fix

One-character fix in two places: `$operationType` -> `$operationTypeEnum`