### PR TITLE
fix: support parameterless policy methods for guest access

### DIFF
--- a/src/Traits/AuthorizableModels.php
+++ b/src/Traits/AuthorizableModels.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
+use ReflectionMethod;
 
 /**
  * Could be used as a trait in a model class and in a repository class.
@@ -31,8 +32,10 @@ trait AuthorizableModels
         }
 
         $resolver = function () {
-            return method_exists(Gate::getPolicyFor(static::newModel()), 'allowRestify')
-                ? Gate::check('allowRestify', get_class(static::newModel()))
+            $policy = Gate::getPolicyFor(static::newModel());
+
+            return method_exists($policy, 'allowRestify')
+                ? static::checkPolicyMethod($policy, 'allowRestify', get_class(static::newModel()))
                 : false;
         };
 
@@ -75,7 +78,11 @@ trait AuthorizableModels
     public static function authorizedToStore(Request $request): bool
     {
         if (static::authorizable()) {
-            return Gate::check('store', static::guessModelClassName());
+            $policy = Gate::getPolicyFor(static::newModel());
+
+            return method_exists($policy, 'store')
+                ? static::checkPolicyMethod($policy, 'store', static::guessModelClassName())
+                : false;
         }
 
         return false;
@@ -84,7 +91,11 @@ trait AuthorizableModels
     public static function authorizedToStoreBulk(Request $request): bool
     {
         if (static::authorizable()) {
-            return Gate::check('storeBulk', static::guessModelClassName());
+            $policy = Gate::getPolicyFor(static::newModel());
+
+            return method_exists($policy, 'storeBulk')
+                ? static::checkPolicyMethod($policy, 'storeBulk', static::guessModelClassName())
+                : false;
         }
 
         return false;
@@ -206,7 +217,15 @@ trait AuthorizableModels
 
         return PolicyCache::resolve(
             PolicyCache::keyForPolicyMethods(static::uriKey(), $ability, $this->resource->getKey()),
-            fn () => Gate::check($ability, $this->resource),
+            function () use ($ability) {
+                $policy = Gate::getPolicyFor($this->model());
+
+                if ($policy && is_string($ability) && method_exists($policy, $ability)) {
+                    return static::checkPolicyMethod($policy, $ability, $this->resource);
+                }
+
+                return Gate::check($ability, $this->resource);
+            },
             $this->model(),
         );
     }
@@ -214,5 +233,24 @@ trait AuthorizableModels
     public static function isRepositoryContext(): bool
     {
         return new static instanceof Repository;
+    }
+
+    /**
+     * Check a policy method, calling it directly when it has no parameters.
+     *
+     * Laravel's Gate requires a nullable $user first parameter to allow guest
+     * access.  When the policy method has zero parameters Gate denies guests
+     * automatically.  This helper detects that case and calls the method
+     * directly so policies stay clean.
+     */
+    protected static function checkPolicyMethod(object $policy, string $method, mixed ...$arguments): bool
+    {
+        $reflection = new ReflectionMethod($policy, $method);
+
+        if ($reflection->getNumberOfParameters() === 0) {
+            return $policy->{$method}();
+        }
+
+        return Gate::check($method, $arguments);
     }
 }

--- a/tests/Feature/ParameterlessPolicyTest.php
+++ b/tests/Feature/ParameterlessPolicyTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Feature;
+
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
+use Binaryk\LaravelRestify\Tests\IntegrationTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+
+class ParameterlessPolicyTest extends IntegrationTestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_SERVER['restify.parameterless.allowRestify'] = true;
+    }
+
+    public function test_unauthenticated_request_is_allowed_when_parameterless_allow_restify_returns_true(): void
+    {
+        Gate::policy(Post::class, ParameterlessAllowPolicy::class);
+
+        $this->logout();
+
+        $_SERVER['restify.parameterless.allowRestify'] = true;
+
+        $this->getJson(PostRepository::route())
+            ->assertOk();
+    }
+
+    public function test_unauthenticated_request_is_denied_when_parameterless_allow_restify_returns_false(): void
+    {
+        Gate::policy(Post::class, ParameterlessAllowPolicy::class);
+
+        $this->logout();
+
+        $_SERVER['restify.parameterless.allowRestify'] = false;
+
+        $this->getJson(PostRepository::route())
+            ->assertForbidden();
+    }
+
+    public function test_authenticated_request_is_allowed_when_parameterless_allow_restify_returns_true(): void
+    {
+        Gate::policy(Post::class, ParameterlessAllowPolicy::class);
+
+        $_SERVER['restify.parameterless.allowRestify'] = true;
+
+        $this->getJson(PostRepository::route())
+            ->assertOk();
+    }
+}
+
+/**
+ * A policy where allowRestify() has zero parameters — no $user argument at all.
+ *
+ * Laravel's Gate denies guest access when a policy method is missing a nullable
+ * $user parameter.  The checkPolicyMethod() helper in AuthorizableModels detects
+ * this and calls the method directly, bypassing Gate's guest-check logic.
+ */
+class ParameterlessAllowPolicy
+{
+    public function allowRestify(): bool
+    {
+        return $_SERVER['restify.parameterless.allowRestify'] ?? true;
+    }
+
+    public function show(): bool
+    {
+        return true;
+    }
+
+    public function store(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
## Problem

Laravel's `Gate` denies guest access to a policy method unless that method declares a nullable `$user` as its first parameter. `Gate::policyAllowsGuests()` inspects the method signature and returns `false` when the parameter is absent, so even a policy like:

```php
public function allowRestify(): bool
{
    return true;
}
```

would return a `403` for unauthenticated requests — despite explicitly returning `true`.

## Fix

`AuthorizableModels` now has a `checkPolicyMethod()` helper that uses `ReflectionMethod` to detect when a policy method has zero parameters. In that case it calls the method directly, bypassing Gate's guest-check logic entirely. When the method does have parameters the existing `Gate::check()` path is used unchanged.

The helper is used in the four existing call sites: `authorizedToUseRepository`, `authorizedToStore`, `authorizedToStoreBulk`, and `authorizedTo`.

## Tests

`tests/Feature/ParameterlessPolicyTest.php` covers three scenarios using a `ParameterlessAllowPolicy` whose `allowRestify()` has no parameters:

- Unauthenticated request is **allowed** when the parameterless policy returns `true` (the key regression case — previously returned 403)
- Unauthenticated request is **denied** when the parameterless policy returns `false`
- Authenticated request is **allowed** when the parameterless policy returns `true`

## Test plan

- [ ] `./vendor/bin/phpunit tests/Feature/ParameterlessPolicyTest.php` — 3 tests pass
- [ ] `./vendor/bin/phpunit tests/Feature/AuthorizableModelsTest.php` — 4 existing tests still pass
- [ ] Verify that a policy with a parameterless `allowRestify(): bool { return true; }` no longer returns 403 for guest requests