### PR TITLE
docs(mcp): document the repository ai-instructions endpoint

### DIFF
--- a/docs-v3/content/docs/6.mcp/7.ai-instructions.md
+++ b/docs-v3/content/docs/6.mcp/7.ai-instructions.md
@@ -1,0 +1,91 @@
+---
+title: AI Instructions
+category: MCP
+---
+
+Every MCP-enabled repository automatically exposes an **AI instructions** endpoint: a single, client-agnostic Markdown document that describes the whole repository's tool surface — its CRUD operations, actions, and getters — together with each tool's description and input parameters (required/optional/type).
+
+It is the "copy for AI" / "copy for LLM" source: paste it into any agent (Claude, Cursor, n8n, your own MCP client) so it knows exactly which tools the resource exposes and how to call them, without a separate discovery round-trip.
+
+The document is generated entirely from the same MCP pipeline that backs the live tools (`get-repository-operations` + `get-operation-details`), so it can never drift from what the MCP server actually exposes.
+
+## Endpoint
+
+```http
+GET /api/restify/{repository}/ai-instructions
+```
+
+The route is registered automatically for every repository — no configuration required. It is protected by the standard Restify middleware, and access is gated by the repository's own authorization: the caller must pass `authorizedToUseRepository()` (the `allowRestify` policy method), exactly like any other repository request.
+
+Only tools the repository actually exposes to MCP are listed. Each operation is filtered through the same gates used during tool discovery:
+
+- The repository's `mcpAllows*()` methods (e.g. `mcpAllowsActions()`, `mcpAllowsGetters()`).
+- Each action/getter's `isShownOnMcp()` visibility and `authorizedToSee()` authorization.
+
+A repository that does not use the `HasMcpTools` trait (or exposes no tools) returns `404`.
+
+## Response
+
+```json
+{
+  "repository": "posts",
+  "instructions": "---\ntool: ...\n---\n# posts — MCP tools\n..."
+}
+```
+
+The `instructions` field is a ready-to-paste Markdown document:
+
+```markdown
+---
+repository: posts
+label: Posts Index
+tools: 4
+generated_by: laravel-restify
+---
+
+# posts — MCP tools
+
+This repository manages the Post model... (the repository description)
+
+Call these tools through the Restify MCP server (e.g. the `execute-operation`
+gateway) using the tool name and the parameters described below.
+
+## posts-index-tool  ·  index
+
+List posts with pagination, search, sorting and filtering.
+
+**Parameters**
+
+- `page` — number, optional. Page number for pagination
+- `perPage` — number, optional. Number of posts per page
+- `search` — string, optional. Search term...
+
+## posts-publish-post-action-tool  ·  action
+
+Publish the selected posts.
+
+**Parameters**
+
+- `resources` — array, required. The ids of the Post resources to act on.
+```
+
+## Example
+
+```bash
+curl -H "Authorization: Bearer {token}" \
+  https://your-app.test/api/restify/posts/ai-instructions
+```
+
+## How it is built
+
+The endpoint reuses the existing MCP machinery rather than re-deriving anything:
+
+- `McpTools::getRepositoryOperations($repository)` enumerates every permitted tool (CRUD + actions + getters).
+- `McpTools::getOperationDetails($repository, $type, $name)` returns each tool's JSON Schema, which is wrapped with `JsonSchemaTypeFactory` to resolve required vs optional fields.
+
+Because both come straight from the MCP server, the Markdown always reflects the live schema produced by your validation rules and repository fields. See [JSON Schema Converter](/docs/mcp/json-schema-converter) for how rules become schema.
+
+## Related
+
+- [MCP Server](/docs/mcp/mcp) — registering and authenticating the server.
+- [MCP Actions](/docs/mcp/actions) and [MCP Getters](/docs/mcp/getters) — exposing tools.


### PR DESCRIPTION
Adds a docs page for the per-repository **AI instructions** endpoint shipped in #732 / `10.4.14`.

`docs-v3/content/docs/6.mcp/7.ai-instructions.md` covers:
- What `GET /api/restify/{repository}/ai-instructions` returns (a client-agnostic Markdown doc of the repo's full MCP tool surface)
- Authorization (repository `allowRestify` + per-tool `isShownOnMcp`/`authorizedToSee`), and the 404 case for non-MCP repositories
- Response shape + a rendered Markdown example
- How it is built by reusing `McpTools::getRepositoryOperations` + `getOperationDetails` (so it never drifts from the live schema)

Internal links and frontmatter follow the existing `6.mcp/*` pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)