### PR TITLE
fix(sort): don't main-qualify relation sort columns

### DIFF
--- a/src/Filters/SortCollection.php
+++ b/src/Filters/SortCollection.php
@@ -113,6 +113,13 @@ class SortCollection extends Collection
     public function qualifyColumns(Model $model): self
     {
         return $this->each(function (SortableFilter $filter) use ($model) {
+            // Relation sorts qualify their column against the related model (in the
+            // subquery/join inside SortableFilter::filter), so qualifying them to the
+            // main table here would point at the wrong table.
+            if ($filter->hasEager()) {
+                return;
+            }
+
             if ($filter->column() && ! str_contains($filter->column(), '.')) {
                 $filter->setColumn($model->qualifyColumn($filter->column()));
             }

--- a/tests/Feature/Filters/SortableFilterTest.php
+++ b/tests/Feature/Filters/SortableFilterTest.php
@@ -114,6 +114,36 @@ class SortableFilterTest extends IntegrationTestCase
             ->json('data.0.attributes.name'));
     }
 
+    public function test_can_sort_by_belongs_to_relation_column_absent_on_main_table(): void
+    {
+        // `posts` has no `name` column; `users` does. The related column must be
+        // qualified against the related table, not the main one (regression: the
+        // sort column was being qualified to `posts.name`, producing invalid SQL).
+        PostRepository::$related = [
+            'user' => BelongsTo::make('user', UserRepository::class),
+        ];
+
+        PostRepository::$sort = [
+            'user' => SortableFilter::make()
+                ->setColumn('name')
+                ->usingRelation(BelongsTo::make('user', UserRepository::class)),
+        ];
+
+        $zoro = User::factory()->create(['name' => 'Zoro']);
+        $alisa = User::factory()->create(['name' => 'Alisa']);
+
+        Post::factory()->create(['title' => 'Z', 'user_id' => $zoro->id]);
+        Post::factory()->create(['title' => 'A', 'user_id' => $alisa->id]);
+
+        $this->getJson(PostRepository::route(query: ['related' => 'user', 'sort' => 'user']))
+            ->assertOk()
+            ->assertJsonPath('data.0.relationships.user.attributes.name', 'Alisa');
+
+        $this->getJson(PostRepository::route(query: ['related' => 'user', 'sort' => '-user']))
+            ->assertOk()
+            ->assertJsonPath('data.0.relationships.user.attributes.name', 'Zoro');
+    }
+
     public function test_sort_qualifies_column_when_searchable_belongs_to_joins_exist(): void
     {
         PostRepository::$related = [


### PR DESCRIPTION
## Problem

Sorting by a `BelongsTo`/`HasOne` relation column via `SortableFilter::usingRelation()` throws a SQL error **when the sort column does not exist on the main table**.

`SortCollection::qualifyColumns()` (added in #725 to disambiguate columns when joins exist) prefixes *every* sort column with the main table. For a relation sort that means `name` becomes `posts.name`, and the correlated subquery then does:

```sql
order by (select "posts"."name" from "users" where ... )  -- no such column: posts.name
```

The whole index request 500s, so paginated data comes back empty.

Found via a downstream app sorting evaluations by `type.name` / `employee.first_name` (columns that live only on the related tables).

## Fix

Skip relation sorts (`$filter->hasEager()`) in `qualifyColumns()` — those qualify their column against the **related** model inside `SortableFilter::filter()` (subquery and join paths). Plain-column qualification from #725 is untouched.

## Tests

- New `test_can_sort_by_belongs_to_relation_column_absent_on_main_table` — sorts `posts` by the related `users.name` (no `name` on `posts`), asserts correct ordering both directions. **Red before the fix** (request 500s), green after.
- Existing sort suite (`SortableFilterTest`, `SortableJoinStrategyTest`, `SortableFieldIntegrationTest`) stays green, including the #725 ambiguity test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)