### PR TITLE
fix(mcp): store tool must create a fresh model on every call

### DIFF
--- a/src/MCP/Concerns/McpStoreTool.php
+++ b/src/MCP/Concerns/McpStoreTool.php
@@ -16,6 +16,8 @@ trait McpStoreTool
 {
     public function storeTool(McpStoreRequest $request): array
     {
+        $this->withResource(static::newModel());
+
         $this->collectFields($request)
             ->forStore($request, $this)
             ->areFiles()

--- a/tests/MCP/McpStoreToolIntegrationTest.php
+++ b/tests/MCP/McpStoreToolIntegrationTest.php
@@ -288,4 +288,94 @@ class McpStoreToolIntegrationTest extends IntegrationTestCase
         $this->assertContains('description', $requiredFields);
         $this->assertContains('user_id', $requiredFields);
     }
+
+    /**
+     * The McpToolsManager singleton caches tool instances (and their repositories), so consecutive
+     * store calls reuse the same repository. Each call must create a fresh record instead of
+     * updating the previously stored one.
+     */
+    public function test_mcp_http_store_tool_creates_distinct_records_on_consecutive_calls(): void
+    {
+        $mcpRepository = new class extends Repository
+        {
+            use HasMcpTools;
+
+            public static $model = Post::class;
+
+            public static string $uriKey = 'test-consecutive-posts';
+
+            public function fields(RestifyRequest $request): array
+            {
+                return [
+                    Field::make('title'),
+                    Field::make('user_id'),
+                ];
+            }
+
+            public function mcpAllowsStore(): bool
+            {
+                return true;
+            }
+        };
+
+        Restify::repositories([
+            $mcpRepository::class,
+        ]);
+
+        Mcp::web('test-consecutive-restify', RestifyServer::class);
+
+        $toolsResponse = $this->postJson('/test-consecutive-restify', [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'tools/list',
+            'params' => [],
+        ]);
+        $toolsResponse->assertOk();
+
+        $availableTools = collect($toolsResponse->json('result.tools'))->pluck('name')->toArray();
+        $storeToolName = collect($availableTools)->filter(fn ($name) => str_contains($name,
+            'test-consecutive-posts') && str_contains($name, 'store'))->first();
+
+        $this->assertNotNull($storeToolName,
+            'Expected test-consecutive-posts store tool not found. Available tools: '.implode(', ', $availableTools));
+
+        $createdIds = [];
+
+        foreach (['First Department', 'Second Department', 'Third Department'] as $index => $title) {
+            $response = $this->postJson('/test-consecutive-restify', [
+                'jsonrpc' => '2.0',
+                'id' => $index + 2,
+                'method' => 'tools/call',
+                'params' => [
+                    'name' => $storeToolName,
+                    'arguments' => [
+                        'title' => $title,
+                        'user_id' => 1,
+                    ],
+                ],
+            ]);
+
+            $response->assertOk();
+
+            $responseData = $response->json();
+
+            if (isset($responseData['error'])) {
+                $this->fail('MCP Error: '.$responseData['error']['message']);
+            }
+
+            $resultContent = json_decode($responseData['result']['content'][0]['text'], true);
+
+            $this->assertEquals($title, $resultContent['data']['attributes']['title']);
+
+            $createdIds[] = $resultContent['data']['id'];
+        }
+
+        $this->assertCount(3, array_unique($createdIds), 'Each store call must create a new record, not update the previous one.');
+
+        $this->assertDatabaseCount('posts', 3);
+
+        foreach (['First Department', 'Second Department', 'Third Department'] as $title) {
+            $this->assertDatabaseHas('posts', ['title' => $title]);
+        }
+    }
 }


### PR DESCRIPTION
## The bug

`McpToolsManager` is a singleton and caches operation tool instances together with their repositories. `Repository::store()` fills and saves the repository's memoized `$resource`, so **consecutive store executions in the same process create the first record and then keep updating it**.

Real-world impact (found via Growee's AI assistant): an agent asked to create three departments issued three correct `execute-operation` store calls — `Design`, `Executive`, `Research` — and every call returned success, but all three responses carried the **same record id**. Only the last name survived in the database:

```
store {"name":"Design"}    -> {"id":"01kty1ghmd...","name":"Design"}     // INSERT
store {"name":"Executive"} -> {"id":"01kty1ghmd...","name":"Executive"}  // UPDATE same row
store {"name":"Research"}  -> {"id":"01kty1ghmd...","name":"Research"}   // UPDATE same row
```

The HTTP store flow never hits this because each web request resolves a fresh repository; the MCP registry broke that assumption by caching instances.

## The fix

Reset the repository's resource to a fresh model at the start of `storeTool()` — mirroring what `updateTool()` (`$this->withResource($model)`) and `storeBulk()` (`$this->resource = static::newModel()`) already do per call.

## Tests

- New regression test: three consecutive `tools/call` store requests through the MCP HTTP endpoint must produce three distinct records. Verified it fails without the fix (`actual size 1` unique ids) and passes with it.
- Full suite: 449 tests, 1896 assertions — OK (4 pre-existing skips). Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)