### PR TITLE
feat(docs): AI-friendly docs — markdown twins, llms.txt, copy page button, upgraded search

### DIFF
--- a/docs-v3/app.config.ts
+++ b/docs-v3/app.config.ts
@@ -1,5 +1,16 @@
 export default defineAppConfig({
     ui: {
+        // Docs search palette: highlighted match state + consistent grouped/footer styling.
+        // `<mark>` tags are injected by @nuxt/ui's fuse highlighter (includeMatches) into
+        // the heading (itemLabelBase) and body-content (itemLabelSuffix) of each result.
+        commandPalette: {
+            slots: {
+                label: 'text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500',
+                itemLabelBase: '[&_mark]:bg-blue-100 [&_mark]:dark:bg-blue-500/25 [&_mark]:text-blue-700 [&_mark]:dark:text-blue-300 [&_mark]:rounded [&_mark]:px-0.5 [&_mark]:font-semibold',
+                itemLabelSuffix: '[&_mark]:bg-blue-100/70 [&_mark]:dark:bg-blue-500/20 [&_mark]:text-blue-700 [&_mark]:dark:text-blue-300 [&_mark]:rounded [&_mark]:px-0.5',
+                footer: 'px-3 py-2.5 border-t border-gray-200 dark:border-gray-800'
+            }
+        },
         accordion: {
             slots: {
                 item: 'border-b border-gray-200 dark:border-gray-700/50 last:border-b-0',

--- a/docs-v3/app.vue
+++ b/docs-v3/app.vue
@@ -7,9 +7,32 @@
         shortcut="meta_k"
         :files="files"
         :navigation="navigation"
-        :fuse="{ resultLimit: 42 }"
-        placeholder="Search documentation..."
-      />
+        :fuse="searchFuse"
+        placeholder="Search the docs, headings and content…"
+      >
+        <template #footer>
+          <div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 w-full text-xs text-gray-500 dark:text-gray-400">
+            <span class="flex items-center gap-1.5">
+              <UIcon name="i-lucide-sparkles" class="size-3.5 text-blue-500 dark:text-blue-400 shrink-0" />
+              <span>
+                <span class="font-medium text-gray-700 dark:text-gray-300">AI tip:</span>
+                append
+                <code class="px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 font-mono text-[0.7rem] text-gray-700 dark:text-gray-300">.md</code>
+                to any docs URL for raw markdown
+              </span>
+            </span>
+            <NuxtLink
+              to="/docs/llms.txt"
+              external
+              target="_blank"
+              class="flex items-center gap-1 font-medium text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              <UIcon name="i-lucide-file-text" class="size-3.5 shrink-0" />
+              /docs/llms.txt
+            </NuxtLink>
+          </div>
+        </template>
+      </LazyUContentSearch>
     </ClientOnly>
   </UApp>
 </template>
@@ -43,4 +66,17 @@ const { data: navigation } = await useAsyncData('navigation', () => queryCollect
 const { data: files } = await useAsyncData('search', () => queryCollectionSearchSections('content'))
 
 const searchTerm = ref('')
+
+// Fuse.js tuning for AI/agent-era docs search: fuzzy, section-aware, generous recall.
+// Keys stay at the CommandPalette default (['label', 'suffix'] = heading + body content) —
+// defu concatenates arrays, so redefining them here would duplicate the defaults.
+const searchFuse = {
+  resultLimit: 20,
+  fuseOptions: {
+    ignoreLocation: true,
+    threshold: 0.3,
+    minMatchCharLength: 2,
+    includeScore: true
+  }
+}
 </script>

--- a/docs-v3/components/TheHeader.vue
+++ b/docs-v3/components/TheHeader.vue
@@ -21,9 +21,11 @@
 
         <div class="flex items-center space-x-4">
           <div class="hidden lg:block">
-            <UContentSearchButton 
+            <UContentSearchButton
               :collapsed="false"
-              placeholder="Search documentation..."
+              :kbds="['meta', 'K']"
+              label="Search documentation…"
+              class="w-64 justify-start text-gray-500 dark:text-gray-400"
             />
           </div>
           
@@ -58,9 +60,11 @@
     
     <div class="lg:hidden px-4 pb-4 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 w-full">
       <div class="pt-4 w-full">
-        <UContentSearchButton 
-          :collapsed="false" 
-          placeholder="Search documentation..."
+        <UContentSearchButton
+          :collapsed="false"
+          :kbds="[]"
+          label="Search documentation…"
+          class="w-full justify-start text-gray-500 dark:text-gray-400"
         />
       </div>
     </div>

--- a/docs-v3/components/docs/CopyPageDropdown.vue
+++ b/docs-v3/components/docs/CopyPageDropdown.vue
@@ -1,0 +1,124 @@
+<template>
+  <div
+    class="inline-flex items-stretch rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm overflow-hidden"
+  >
+    <button
+      type="button"
+      class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+      :aria-label="copied ? 'Copied' : 'Copy page as Markdown'"
+      @click="copyPage"
+    >
+      <UIcon
+        :name="copied ? 'i-lucide-check' : 'i-lucide-copy'"
+        class="w-4 h-4 shrink-0"
+        :class="copied ? 'text-green-600 dark:text-green-400' : ''"
+      />
+      <span>{{ copied ? 'Copied' : 'Copy page' }}</span>
+    </button>
+
+    <UDropdownMenu
+      :items="items"
+      :content="{ align: 'end', side: 'bottom', sideOffset: 6 }"
+      :ui="{ content: 'w-72' }"
+    >
+      <button
+        type="button"
+        class="inline-flex items-center px-2 border-l border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-200 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+        aria-label="More copy options"
+      >
+        <UIcon name="i-lucide-chevron-down" class="w-4 h-4" />
+      </button>
+
+      <template #item-label="{ item }">
+        <div class="flex flex-col text-left">
+          <span class="text-sm font-medium text-gray-900 dark:text-white">{{ item.label }}</span>
+          <span v-if="item.description" class="text-xs text-gray-500 dark:text-gray-400">
+            {{ item.description }}
+          </span>
+        </div>
+      </template>
+    </UDropdownMenu>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const route = useRoute()
+const config = useRuntimeConfig()
+const { copied, copyToClipboard } = useClipboardCopy()
+
+const siteUrl = config.public.siteUrl as string
+
+const mdPath = computed(() => `${route.path.replace(/\/$/, '')}.md`)
+const absoluteMdUrl = computed(() => `${siteUrl}${mdPath.value}`)
+
+const llmPrompt = computed(
+  () => `Read from ${absoluteMdUrl.value} so I can ask questions about it.`
+)
+
+const chatGptUrl = computed(
+  () => `https://chatgpt.com/?hints=search&q=${encodeURIComponent(llmPrompt.value)}`
+)
+
+const claudeUrl = computed(
+  () => `https://claude.ai/new?q=${encodeURIComponent(llmPrompt.value)}`
+)
+
+async function fetchMarkdown(): Promise<string> {
+  try {
+    const response = await fetch(mdPath.value)
+
+    if (response.ok) {
+      const text = await response.text()
+
+      if (text && !text.trimStart().startsWith('<')) {
+        return text
+      }
+    }
+  } catch {
+    // Fall through to URL fallback (e.g. .md twin missing in dev)
+  }
+
+  return absoluteMdUrl.value
+}
+
+async function copyPage(): Promise<void> {
+  const markdown = await fetchMarkdown()
+  await copyToClipboard(markdown)
+}
+
+const items = computed(() => [
+  [
+    {
+      label: 'Copy page',
+      description: 'Copy page as Markdown for LLMs',
+      icon: 'i-lucide-file-text',
+      onSelect: copyPage
+    },
+    {
+      label: 'View as Markdown',
+      description: 'Open the raw Markdown in a new tab',
+      icon: 'i-lucide-file-code',
+      to: mdPath.value,
+      target: '_blank'
+    }
+  ],
+  [
+    {
+      label: 'Open in ChatGPT',
+      description: 'Ask ChatGPT about this page',
+      icon: 'i-lucide-bot',
+      to: chatGptUrl.value,
+      target: '_blank'
+    },
+    {
+      label: 'Open in Claude',
+      description: 'Ask Claude about this page',
+      icon: 'i-lucide-sparkles',
+      to: claudeUrl.value,
+      target: '_blank'
+    }
+  ]
+])
+</script>

--- a/docs-v3/nuxt.config.ts
+++ b/docs-v3/nuxt.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url'
+
 const docsRoutes = [
   '/',
   '/docs',
@@ -135,6 +137,20 @@ export default defineNuxtConfig({
   // Cloudflare Pages does not understand, and exact-match rules would additionally be
   // prerendered as meta-refresh stub HTML that shadows the redirect with a 200.
 
+  // Emit Forge-style raw markdown twins and llms.txt indexes into the static
+  // output at build time. Runs after Nitro has staged public assets, so the files
+  // land in the final publicDir (dist/) alongside the prerendered pages.
+  hooks: {
+    async 'nitro:build:public-assets'(nitro) {
+      const { generateLlms } = await import('./scripts/generate-llms.mjs')
+      await generateLlms({
+        contentDir: fileURLToPath(new URL('./content/docs', import.meta.url)),
+        outputDir: nitro.options.output.publicDir,
+        siteUrl: 'https://laravel-restify.com'
+      })
+    }
+  },
+
   // TypeScript configuration
   typescript: {
     typeCheck: false
@@ -144,6 +160,22 @@ export default defineNuxtConfig({
   ssr: true,
   nitro: {
     preset: 'cloudflare_pages',
+    // Collapse the per-file static excludes into a handful of wildcards so the
+    // generated dist/_routes.json stays well under Cloudflare Pages' hard limit
+    // of 100 rules. Nitro seeds `exclude` from this config first, converts each
+    // trailing `/*` into a `/**` glob to skip matching files during its own
+    // asset walk, then appends the remaining root assets. Without this, every
+    // prerendered /docs page plus its raw `.md` twin and the llms.txt indexes
+    // were emitted as individual excludes, pinning the file at exactly 100 rules
+    // (one content page away from a rejected deploy). `/docs/*` covers all docs
+    // HTML pages, their `.md` twins, and /docs/llms{,-full}.txt in one rule.
+    cloudflare: {
+      pages: {
+        routes: {
+          exclude: ['/docs/*', '/docs.md', '/llms.txt']
+        }
+      }
+    },
     prerender: {
       failOnError: false,
       crawlLinks: true,

--- a/docs-v3/pages/[...slug].vue
+++ b/docs-v3/pages/[...slug].vue
@@ -2,6 +2,10 @@
   <NuxtLayout>
     <div v-if="post">
       <article>
+        <div v-if="isDocsPage" class="flex justify-end mb-4">
+          <CopyPageDropdown />
+        </div>
+
         <header class="mb-8">
           <h1 class="text-4xl font-bold text-gray-900 dark:text-white mb-4">
             {{ post.title }}
@@ -41,6 +45,8 @@ const route = useRoute()
 
 const pathSegments = Array.isArray(route.params.slug) ? route.params.slug : [route.params.slug || '']
 const contentPath = `/${pathSegments.join('/')}`
+
+const isDocsPage = computed(() => contentPath === '/docs' || contentPath.startsWith('/docs/'))
 
 const { data: post } = await useAsyncData(`content-${contentPath}`, function fetchContent() {
   return queryCollection('content').path(contentPath).first()

--- a/docs-v3/public/_headers
+++ b/docs-v3/public/_headers
@@ -8,3 +8,21 @@
   cache-control: public, max-age=31536000, immutable
 /_nuxt/*
   cache-control: public, max-age=31536000, immutable
+
+# Serve the Forge-style raw markdown twins and llms.txt indexes as UTF-8 markdown
+# so AI agents and browsers render them as text rather than downloading them.
+/docs/*.md
+  content-type: text/markdown; charset=utf-8
+  cache-control: public, max-age=3600
+/docs.md
+  content-type: text/markdown; charset=utf-8
+  cache-control: public, max-age=3600
+/llms.txt
+  content-type: text/plain; charset=utf-8
+  cache-control: public, max-age=3600
+/docs/llms.txt
+  content-type: text/plain; charset=utf-8
+  cache-control: public, max-age=3600
+/docs/llms-full.txt
+  content-type: text/plain; charset=utf-8
+  cache-control: public, max-age=3600

--- a/docs-v3/scripts/generate-llms.mjs
+++ b/docs-v3/scripts/generate-llms.mjs
@@ -1,0 +1,264 @@
+// Build-time generator for the Forge-style raw-markdown export pipeline.
+//
+// Emits, into the static output (dist/ during `nuxt generate`):
+//   - a raw ".md" twin for every docs page (page route + ".md")
+//   - /docs/llms.txt        (index of every page, grouped by sidebar section)
+//   - /docs/llms-full.txt   (every page's full markdown concatenated in nav order)
+//   - /llms.txt             (llmstxt.org root convention, identical to /docs/llms.txt)
+//
+// Wired into the build via a `nitro:build:public-assets` hook in nuxt.config.ts,
+// and runnable standalone (see the CLI entrypoint at the bottom) for verification.
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const NUMERIC_PREFIX = /^\d+\./
+
+function stripNumericPrefix(segment) {
+    return segment.replace(NUMERIC_PREFIX, '')
+}
+
+function titleize(slug) {
+    return slug
+        .split('-')
+        .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : word))
+        .join(' ')
+}
+
+function parseFrontmatter(raw) {
+    if (!raw.startsWith('---')) {
+        return { data: {}, body: raw }
+    }
+
+    const end = raw.indexOf('\n---', 3)
+    if (end === -1) {
+        return { data: {}, body: raw }
+    }
+
+    const block = raw.slice(3, end)
+    const body = raw.slice(raw.indexOf('\n', end + 1) + 1)
+
+    const data = {}
+    for (const line of block.split('\n')) {
+        const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/)
+        if (!match) {
+            continue
+        }
+        let value = match[2].trim()
+        if (
+            (value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'"))
+        ) {
+            value = value.slice(1, -1)
+        }
+        data[match[1]] = value
+    }
+
+    return { data, body: body.replace(/^\n+/, '') }
+}
+
+function firstParagraph(body) {
+    for (const rawLine of body.split('\n')) {
+        const line = rawLine.trim()
+        if (!line) {
+            continue
+        }
+        if (line.startsWith('#') || line.startsWith('```') || line.startsWith('::') || line.startsWith('>')) {
+            continue
+        }
+        const plain = line
+            .replace(/\*\*/g, '')
+            .replace(/[*_`]/g, '')
+            .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+        return plain.length > 200 ? `${plain.slice(0, 197).trimEnd()}...` : plain
+    }
+    return ''
+}
+
+async function walkMarkdown(dir) {
+    const entries = await fs.readdir(dir, { withFileTypes: true })
+    const files = []
+
+    for (const entry of entries) {
+        const full = path.join(dir, entry.name)
+        if (entry.isDirectory()) {
+            files.push(...(await walkMarkdown(full)))
+        } else if (entry.isFile() && entry.name.endsWith('.md')) {
+            files.push(full)
+        }
+    }
+
+    return files
+}
+
+async function readSectionTitle(contentDir, sectionDir) {
+    try {
+        const raw = await fs.readFile(path.join(contentDir, sectionDir, '.navigation.yml'), 'utf8')
+        const match = raw.match(/^title:\s*(.*)$/m)
+        if (match) {
+            return match[1].trim().replace(/^["']|["']$/g, '')
+        }
+    } catch {
+        // No navigation file — fall back to a titleized slug.
+    }
+    return titleize(stripNumericPrefix(sectionDir))
+}
+
+function toPageMeta(contentDir, filePath) {
+    const relative = path.relative(contentDir, filePath)
+    const segments = relative.split(path.sep)
+
+    const numericFile = segments[segments.length - 1]
+    const numericSection = segments.length > 1 ? segments[0] : null
+
+    const cleaned = segments.map((segment) => stripNumericPrefix(segment))
+    cleaned[cleaned.length - 1] = cleaned[cleaned.length - 1].replace(/\.md$/, '')
+
+    if (cleaned[cleaned.length - 1] === 'index') {
+        cleaned.pop()
+    }
+
+    const routePath = ['/docs', ...cleaned].join('/').replace(/\/$/, '') || '/docs'
+    const mdRelative = routePath === '/docs' ? 'docs.md' : `${routePath.replace(/^\//, '')}.md`
+
+    return {
+        numericSection,
+        numericFile,
+        section: numericSection,
+        routePath,
+        mdRelative
+    }
+}
+
+export async function generateLlms({ contentDir, outputDir, siteUrl }) {
+    const base = siteUrl.replace(/\/$/, '')
+    const files = await walkMarkdown(contentDir)
+
+    const pages = []
+    for (const filePath of files) {
+        const raw = await fs.readFile(filePath, 'utf8')
+        const { data, body } = parseFrontmatter(raw)
+        const meta = toPageMeta(contentDir, filePath)
+
+        const title = data.title || titleize(stripNumericPrefix(meta.numericFile.replace(/\.md$/, '')))
+        const description = data.description || firstParagraph(body)
+
+        pages.push({ ...meta, title, description, body })
+    }
+
+    pages.sort((a, b) => {
+        const sa = a.numericSection || ''
+        const sb = b.numericSection || ''
+        if (sa !== sb) {
+            return sa.localeCompare(sb, undefined, { numeric: true })
+        }
+        return a.numericFile.localeCompare(b.numericFile, undefined, { numeric: true })
+    })
+
+    const sectionTitles = new Map()
+    for (const page of pages) {
+        if (page.section && !sectionTitles.has(page.section)) {
+            sectionTitles.set(page.section, await readSectionTitle(contentDir, page.section))
+        }
+    }
+
+    await writeMarkdownTwins(pages, outputDir, base)
+    const llmsTxt = buildLlmsTxt(pages, sectionTitles, base)
+    const llmsFullTxt = buildLlmsFullTxt(pages, base)
+
+    await writeFile(path.join(outputDir, 'docs', 'llms.txt'), llmsTxt)
+    await writeFile(path.join(outputDir, 'docs', 'llms-full.txt'), llmsFullTxt)
+    await writeFile(path.join(outputDir, 'llms.txt'), llmsTxt)
+
+    return { pages: pages.length }
+}
+
+function buildBanner(base) {
+    return [
+        '> ## Documentation Index',
+        `> Fetch the complete documentation index at: ${base}/docs/llms.txt`,
+        '> Use this file to discover all available pages before exploring further.'
+    ].join('\n')
+}
+
+async function writeMarkdownTwins(pages, outputDir, base) {
+    const banner = buildBanner(base)
+
+    for (const page of pages) {
+        const parts = [banner, '', `# ${page.title}`]
+        if (page.description) {
+            parts.push('', `> ${page.description}`)
+        }
+        parts.push('', page.body.trimEnd(), '')
+
+        await writeFile(path.join(outputDir, page.mdRelative), parts.join('\n'))
+    }
+}
+
+function buildLlmsTxt(pages, sectionTitles, base) {
+    const intro = pages.find((page) => page.routePath === '/docs')
+    const lines = ['# Laravel Restify', '']
+    lines.push(
+        intro?.description ||
+            'Transform Laravel Eloquent models into JSON:API endpoints and MCP servers automatically.'
+    )
+    lines.push('')
+
+    if (intro) {
+        lines.push(`- [${intro.title}](${base}/${intro.mdRelative}): ${intro.description}`)
+    }
+
+    let currentSection = null
+    for (const page of pages) {
+        if (page === intro) {
+            continue
+        }
+        if (page.section !== currentSection) {
+            currentSection = page.section
+            lines.push('')
+            lines.push(`## ${sectionTitles.get(currentSection) || titleize(stripNumericPrefix(currentSection))}`)
+            lines.push('')
+        }
+        const suffix = page.description ? `: ${page.description}` : ''
+        lines.push(`- [${page.title}](${base}/${page.mdRelative})${suffix}`)
+    }
+
+    lines.push('')
+    return lines.join('\n')
+}
+
+function buildLlmsFullTxt(pages, base) {
+    const blocks = pages.map((page) => {
+        const parts = [`# ${page.title}`, '', `Source: ${base}${page.routePath}`]
+        if (page.description) {
+            parts.push('', `> ${page.description}`)
+        }
+        parts.push('', page.body.trimEnd())
+        return parts.join('\n')
+    })
+
+    return `${blocks.join('\n\n---\n\n')}\n`
+}
+
+async function writeFile(filePath, contents) {
+    await fs.mkdir(path.dirname(filePath), { recursive: true })
+    await fs.writeFile(filePath, contents, 'utf8')
+}
+
+const isCli = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+
+if (isCli) {
+    const contentDir = process.argv[2] || path.resolve(process.cwd(), 'content/docs')
+    const outputDir = process.argv[3] || path.resolve(process.cwd(), 'dist')
+    const siteUrl = process.env.SITE_URL || 'https://laravel-restify.com'
+
+    generateLlms({ contentDir, outputDir, siteUrl })
+        .then((result) => {
+            process.stdout.write(`[generate-llms] wrote ${result.pages} pages into ${outputDir}\n`)
+        })
+        .catch((error) => {
+            console.error('[generate-llms] failed:', error)
+            process.exit(1)
+        })
+}


### PR DESCRIPTION
Makes the docs site AI/agent-friendly, modeled on the Laravel Forge (Mintlify) docs.

## What's included

### Raw markdown twins + llms.txt (build-time, fully static)
- Every docs page now has a raw-markdown twin at its URL + `.md` (e.g. `/docs/mcp/mcp.md`), starting with a banner pointing agents at the docs index — 32 pages emitted.
- `/docs/llms.txt` — index of all pages grouped by sidebar section with descriptions and absolute `.md` links.
- `/docs/llms-full.txt` — all pages concatenated for one-shot LLM context.
- `/llms.txt` at the site root per the llmstxt.org convention.
- Generated by `scripts/generate-llms.mjs`, wired into `nuxt generate` via the `nitro:build:public-assets` hook, so it works on the Cloudflare Pages static deploy with no runtime server.
- `_headers` serves `.md`/llms files with markdown content types; `/docs/*` is wildcard-excluded in `_routes.json` to stay under Cloudflare Pages' 100-rule limit.

### Copy page button (Forge-style)
- Split button on every docs page: **Copy page** copies the page as markdown to the clipboard; the dropdown adds **View as Markdown**, **Open in ChatGPT**, and **Open in Claude** with a pre-filled prompt pointing at the page's `.md` URL.
- Graceful dev-mode fallback when the static `.md` twin doesn't exist.

### Search upgrade
- The search modal was effectively exact-match only (Fuse threshold 0.1). Now: fuzzy, section-level full-text search (headings + body), grouped results, and an AI hint in the modal footer (append `.md` to any docs URL / `/docs/llms.txt`).

## Test plan
- [x] `npm run build` (nuxt generate, cloudflare_pages preset) passes
- [x] 32 `.md` twins verified in `dist/` with banner + title + description
- [x] `dist/llms.txt`, `dist/docs/llms.txt`, `dist/docs/llms-full.txt` well-formed
- [x] `_routes.json` at 29 rules (was at the 100 ceiling before the wildcard fix)
- [x] `vue-tsc` clean on changed components
- [ ] Visual check of Copy page button + search on the Pages preview deploy