### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/Commands/PolicyCommand.php
+++ b/src/Commands/PolicyCommand.php
@@ -12,6 +12,8 @@ class PolicyCommand extends GeneratorCommand
 
     protected $description = 'Create a new policy for a specific model.';
 
+    protected $type = 'Policy';
+
     public function handle()
     {
         if (parent::handle() === false && ! $this->option('force')) {


### PR DESCRIPTION
ErrorException: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in ...vendor/laravel/framework/src/Illuminate/Console/GeneratorCommand.php:495

